### PR TITLE
Add scripts for installing on supported machines

### DIFF
--- a/e3sm_supported_machines/acme1_aims4_create_new_env.bash
+++ b/e3sm_supported_machines/acme1_aims4_create_new_env.bash
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# Modify the following to update the e3sm-unified version,
+# the python version or to specify whether to support x-windows
+# under uv-cdat (x) or not (nox).  Typically, run the script once
+# each for x and nox
+version=1.1.2
+python=2
+x_or_nox=nox
+
+# The rest of the script should not need to be modified
+miniconda=Miniconda${python}-latest-Linux-x86_64.sh
+base_path=/usr/local/e3sm_unified/envs/e3sm_unified_${version}_py${python}_${x_or_nox}
+
+channels="-c conda-forge -c e3sm -c acme -c uvcdat"
+if [ $x_or_nox = "x" ]; then
+   packages="e3sm-unified=${version}"
+else
+   packages="e3sm-unified=${version} mesalib"
+fi
+
+wget https://repo.continuum.io/miniconda/$miniconda
+/bin/bash $miniconda -b -p $base_path
+rm $miniconda
+export PATH="$base_path/bin:$PATH"
+conda config --add channels conda-forge
+conda update -y --all
+conda install -y $channels $packages
+# force reinstall of packages messed up by toher packages:
+# * six is messed up by vtk-cdat
+# * libgcc* and libstdcxx-ng are messed up by gcc
+conda install -y --force -c conda-forge six libgcc libgcc-ng libstdcxx-ng
+cd $base_path
+chown -R $USER:climate .
+chmod -R g+rX .
+chmod -R g-w .
+chmod -R o-rwx .

--- a/e3sm_supported_machines/blues_create_new_env.bash
+++ b/e3sm_supported_machines/blues_create_new_env.bash
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# Modify the following to update the e3sm-unified version,
+# the python version or to specify whether to support x-windows
+# under uv-cdat (x) or not (nox).  Typically, run the script once
+# each for x and nox
+version=1.1.2
+python=2
+x_or_nox=nox
+
+# The rest of the script should not need to be modified
+miniconda=Miniconda${python}-latest-Linux-x86_64.sh
+base_path=/lcrc/soft/climate/e3sm-unified/${version}_py${python}_${x_or_nox}
+
+channels="-c conda-forge -c e3sm -c acme -c uvcdat"
+if [ $x_or_nox = "x" ]; then
+   packages="e3sm-unified=${version}"
+else
+   packages="e3sm-unified=${version} mesalib"
+fi
+
+wget https://repo.continuum.io/miniconda/$miniconda
+/bin/bash $miniconda -b -p $base_path
+rm $miniconda
+export PATH="$base_path/bin:$PATH"
+conda config --add channels conda-forge
+conda update -y --all
+conda install -y $channels $packages
+# force reinstall of packages messed up by toher packages:
+# * six is messed up by vtk-cdat
+# * libgcc* and libstdcxx-ng are messed up by gcc
+conda install -y --force -c conda-forge six libgcc libgcc-ng libstdcxx-ng
+cd $base_path
+chown -R $USER:OceanClimate .
+chmod -R g+rX .
+chmod -R g-w .
+chmod -R o-rwx .
+

--- a/e3sm_supported_machines/nersc_create_new_env.bash
+++ b/e3sm_supported_machines/nersc_create_new_env.bash
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# Modify the following to update the e3sm-unified version,
+# the python version or to specify whether to support x-windows
+# under uv-cdat (x) or not (nox).  Typically, run the script once
+# each for x and nox
+version=1.1.2
+python=2
+x_or_nox=nox
+
+# The rest of the script should not need to be modified
+machine=$NERSC_HOST
+
+miniconda=Miniconda${python}-latest-Linux-x86_64.sh
+base_path=/global/project/projectdirs/acme/software/anaconda_envs/${machine}_e3sm_unified_${version}_py${python}_${x_or_nox}
+
+channels="-c conda-forge -c e3sm -c acme -c uvcdat"
+if [ $x_or_nox = "x" ]; then
+   packages="e3sm-unified=${version}"
+else
+   packages="e3sm-unified=${version} mesalib"
+fi
+
+wget https://repo.continuum.io/miniconda/$miniconda
+/bin/bash $miniconda -b -p $base_path
+rm $miniconda
+export PATH="$base_path/bin:$PATH"
+conda config --add channels conda-forge
+conda update -y --all
+conda install -y $channels $packages
+# force reinstallation of several packages:
+# * six gets messed up by vtk-cdat
+# * the rest are messed up by gcc
+conda install -y --force -c conda-forge six libgcc libgcc-ng libstdcxx-ng
+cd $base_path
+chown -R $USER:acme .
+chmod -R g+rX .
+chmod -R g-w .
+chmod -R o-rwx .

--- a/e3sm_supported_machines/olcf_create_new_env.bash
+++ b/e3sm_supported_machines/olcf_create_new_env.bash
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# Modify the following to update the e3sm-unified version,
+# the python version or to specify whether to support x-windows
+# under uv-cdat (x) or not (nox).  Typically, run the script once
+# each for x and nox
+version=1.1.2
+python=2
+x_or_nox=nox
+
+# The rest of the script should not need to be modified
+miniconda=Miniconda${python}-latest-Linux-x86_64.sh
+base_path=/ccs/proj/cli115/software/anaconda_envs/e3sm_unified_${version}_py${python}_${x_or_nox}
+
+channels="-c conda-forge -c e3sm -c acme -c uvcdat"
+if [ $x_or_nox = "x" ]; then
+   packages="e3sm-unified=${version}"
+else
+   packages="e3sm-unified=${version} mesalib"
+fi
+
+wget https://repo.continuum.io/miniconda/$miniconda
+/bin/bash $miniconda -b -p $base_path
+rm $miniconda
+export PATH="$base_path/bin:$PATH"
+conda config --add channels conda-forge
+conda update -y --all
+conda install -y $channels $packages
+# force reinstall of packages messed up by toher packages:
+# * six is messed up by vtk-cdat
+# * libgcc* and libstdcxx-ng are messed up by gcc
+conda install -y --force -c conda-forge six libgcc libgcc-ng libstdcxx-ng
+cd $base_path
+chown -R $USER:cli115 .
+chmod -R g+rX .
+chmod -R g-w .
+chmod -R o-rwx .
+

--- a/e3sm_supported_machines/theta_create_new_env.bash
+++ b/e3sm_supported_machines/theta_create_new_env.bash
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# Modify the following to update the e3sm-unified version,
+# the python version or to specify whether to support x-windows
+# under uv-cdat (x) or not (nox).  Typically, run the script once
+# each for x and nox
+version=1.1.2
+python=2
+x_or_nox=nox
+
+# The rest of the script should not need to be modified
+miniconda=Miniconda${python}-latest-Linux-x86_64.sh
+base_path=/projects/ClimateEnergy_2/software/e3sm_unified/e3sm_unified_${version}_py${python}_${x_or_nox}
+
+channels="-c conda-forge -c e3sm -c acme -c uvcdat"
+if [ $x_or_nox = "x" ]; then
+   packages="e3sm-unified=${version}"
+else
+   packages="e3sm-unified=${version} mesalib"
+fi
+
+wget https://repo.continuum.io/miniconda/$miniconda
+/bin/bash $miniconda -b -p $base_path
+rm $miniconda
+export PATH="$base_path/bin:$PATH"
+conda config --add channels conda-forge
+conda update -y --all
+conda install -y $channels $packages
+# force reinstall of packages messed up by toher packages:
+# * six is messed up by vtk-cdat
+# * libgcc* and libstdcxx-ng are messed up by gcc
+conda install -y --force -c conda-forge six libgcc libgcc-ng libstdcxx-ng
+cd $base_path
+chown -R $USER:OceanClimate .
+chmod -R g+rX .
+chmod -R g-w .
+chmod -R o-rwx .
+


### PR DESCRIPTION
These scripts can be run from any temporary directory (where miniconda will be downloaded) to install e3sm-unified on the desired machine.