### PR TITLE
Add "conda clean" to each machine script

### DIFF
--- a/e3sm_supported_machines/acme1_aims4_create_new_env.bash
+++ b/e3sm_supported_machines/acme1_aims4_create_new_env.bash
@@ -30,6 +30,8 @@ conda install -y $channels $packages
 # * six is messed up by vtk-cdat
 # * libgcc* and libstdcxx-ng are messed up by gcc
 conda install -y --force -c conda-forge six libgcc libgcc-ng libstdcxx-ng
+# delete the tarballs and any unused packages
+conda clean -y -p -t
 cd $base_path
 chown -R $USER:climate .
 chmod -R g+rX .

--- a/e3sm_supported_machines/blues_create_new_env.bash
+++ b/e3sm_supported_machines/blues_create_new_env.bash
@@ -30,6 +30,8 @@ conda install -y $channels $packages
 # * six is messed up by vtk-cdat
 # * libgcc* and libstdcxx-ng are messed up by gcc
 conda install -y --force -c conda-forge six libgcc libgcc-ng libstdcxx-ng
+# delete the tarballs and any unused packages
+conda clean -y -p -t
 cd $base_path
 chown -R $USER:OceanClimate .
 chmod -R g+rX .

--- a/e3sm_supported_machines/nersc_create_new_env.bash
+++ b/e3sm_supported_machines/nersc_create_new_env.bash
@@ -32,6 +32,8 @@ conda install -y $channels $packages
 # * six gets messed up by vtk-cdat
 # * the rest are messed up by gcc
 conda install -y --force -c conda-forge six libgcc libgcc-ng libstdcxx-ng
+# delete the tarballs and any unused packages
+conda clean -y -p -t
 cd $base_path
 chown -R $USER:acme .
 chmod -R g+rX .

--- a/e3sm_supported_machines/olcf_create_new_env.bash
+++ b/e3sm_supported_machines/olcf_create_new_env.bash
@@ -30,6 +30,8 @@ conda install -y $channels $packages
 # * six is messed up by vtk-cdat
 # * libgcc* and libstdcxx-ng are messed up by gcc
 conda install -y --force -c conda-forge six libgcc libgcc-ng libstdcxx-ng
+# delete the tarballs and any unused packages
+conda clean -y -p -t
 cd $base_path
 chown -R $USER:cli115 .
 chmod -R g+rX .

--- a/e3sm_supported_machines/theta_create_new_env.bash
+++ b/e3sm_supported_machines/theta_create_new_env.bash
@@ -30,6 +30,8 @@ conda install -y $channels $packages
 # * six is messed up by vtk-cdat
 # * libgcc* and libstdcxx-ng are messed up by gcc
 conda install -y --force -c conda-forge six libgcc libgcc-ng libstdcxx-ng
+# delete the tarballs and any unused packages
+conda clean -y -p -t
 cd $base_path
 chown -R $USER:ClimateEnergy_2 .
 chmod -R g+rX .


### PR DESCRIPTION
This removes some unneeded tarballs and unused packages at the end of the install to save disk space and total number of files.