### PR TITLE
Fix cdat incompatibility with specified libnetcdf version

### DIFF
--- a/e3sm_unified_metapackage.bash
+++ b/e3sm_unified_metapackage.bash
@@ -1,5 +1,5 @@
 #!/bin/bash
-BUILD=0
+BUILD=1
 VERSION=1.2.1
 
 
@@ -9,7 +9,7 @@ conda metapackage -c conda-forge -c e3sm -c cdat \
     "cdat ==8.0" \
     "cdat_info ==8.0" \
     "distarray ==2.12.2" \
-    "cdms2 ==3.0" \
+    "cdms2 ==3.0.1" \
     "cdtime ==3.0" \
     "cdutil ==8.0" \
     "genutil ==8.0" \

--- a/e3sm_unified_metapackage.bash
+++ b/e3sm_unified_metapackage.bash
@@ -26,7 +26,7 @@ conda metapackage -c conda-forge -c e3sm -c cdat \
     "cibots ==0.2" \
     "xarray ==0.10.3" \
     "dask ==0.17.2" \
-    "nco ==4.7.5" \
+    "nco ==4.7.6" \
     "lxml ==4.2.1" \
     "sympy ==1.1.1" \
     "pyproj ==1.9.5.1" \


### PR DESCRIPTION
This is accomplished by switching to cdms2 v. 3.0.1, which is on conda-forge rather than the cdat channel.