### PR TITLE
Add support for creating module files

### DIFF
--- a/e3sm_supported_machines/module_template
+++ b/e3sm_supported_machines/module_template
@@ -1,0 +1,51 @@
+#%Module1.0
+##
+
+## Required internal variables
+
+set		name		e3sm-unified
+set		version		@version_py@python_@x_or_nox
+set		root		@base_path
+
+## List conflicting modules here
+
+conflict $name python
+
+## List prerequisite modules here
+
+# prereq
+
+## Required for SVN hook to generate SWDB entry
+
+set		fullname	Python
+set		externalurl	http://www.python.org/
+set		maincategory	applications
+set		subcategory	programming
+set		description	"Python programming language"
+
+## Required for "module help ..."
+
+proc ModulesHelp { } {
+  global description externalurl
+  puts stderr "Description - $description"
+  puts stderr "Other Docs  - $externalurl"
+}
+
+## Required for "module display ..." and SWDB
+
+module-whatis			"$description"
+
+## Software-specific settings exported to user environment
+
+setenv          PYTHON_DIR      "$root"
+setenv          PYTHONUSERBASE  $env(HOME)/.local/e3sm_unified_$version
+prepend-path    PATH        $root/bin
+
+## Log "module load ..." commands
+
+if [ module-info mode load ] {
+  set usgsbin /global/common/shared/usg/sbin
+  if [ expr [ file exists $usgsbin/logmod ] ] {
+    exec $usgsbin/logmod ${name} ${version}
+  }
+}


### PR DESCRIPTION
Module files are created in a specified directory for all machines that support module files.

Automatic tests are performed both on the conda environment (loaded by `conda activate`) and the associated module (loaded by `module load`).

Add directories for LANL's grizzly machine and also for xylar's laptop (for testing)