### PR TITLE
Update to 1.2.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,3 @@ To install without x-windows, use:
 conda install -c conda-forge -c e3sm -c cdat e3sm-unified mesalib
 ```
 
-Note: CDAT's version of VTK automatically installs an older version of `six`
-that overwrites the newer version required by many other packages.  Similarly,
-the `gcc` package downgrades `libstdcxx`, in conflict with several related
-packages.  To overcome these issues, it is currently necessary to force a
-reinstall of 4 packages once e3sm-unified has been installed:
-```
-conda install -y --force -c conda-forge six libgcc libgcc-ng libstdcxx-ng
-```

--- a/e3sm_supported_machines/create_new_env.bash
+++ b/e3sm_supported_machines/create_new_env.bash
@@ -23,7 +23,7 @@ check_env () {
 # the python version(s) are installed and whether to make an environment with
 # x-windows support under cdat (x), without (nox) or both (nox x).  Typically,
 # both x and nox environments should be created.
-versions=(1.2.1)
+versions=(1.2.2)
 pythons=(2.7)
 x_or_noxs=(nox x)
 

--- a/e3sm_supported_machines/create_new_env.bash
+++ b/e3sm_supported_machines/create_new_env.bash
@@ -36,6 +36,7 @@ set -e
 
 world_read="False"
 support_mod="True"
+channels="-c conda-forge -c e3sm -c cdat"
 
 # The rest of the script should not need to be modified
 if [[ $HOSTNAME = "edison"* ]]; then
@@ -72,11 +73,10 @@ elif [[ $HOSTNAME = "eleven"* ]]; then
   base_path="/home/xylar/miniconda3"
   mod_path="/home/xylar/test_mod"
   group="xylar"
+  channels="$channels --use-local"
 else
   echo "Unknown host name $HOSTNAME.  Add env_path and group for this machine to the script."
 fi
-
-channels="-c conda-forge -c e3sm -c cdat"
 
 if [ ! -d $base_path ]; then
   miniconda=Miniconda2-latest-Linux-x86_64.sh

--- a/e3sm_unified_metapackage.bash
+++ b/e3sm_unified_metapackage.bash
@@ -1,6 +1,6 @@
 #!/bin/bash
-BUILD=1
-VERSION=1.2.1
+BUILD=0
+VERSION=1.2.2
 
 
 conda metapackage -c conda-forge -c e3sm -c cdat \
@@ -24,17 +24,17 @@ conda metapackage -c conda-forge -c e3sm -c cdat \
     "e3sm_nex ==0.0.2" \
     "e3sm_diags ==1.3.4" \
     "cibots ==0.2" \
-    "xarray ==0.10.3" \
-    "dask ==0.17.2" \
+    "xarray ==0.10.8" \
+    "dask ==0.18.2" \
     "nco ==4.7.6" \
-    "lxml ==4.2.1" \
-    "sympy ==1.1.1" \
-    "pyproj ==1.9.5.1" \
-    "pytest ==3.5.0" \
-    "shapely  ==1.6.4" \
-    "cartopy  ==0.16.0" \
+    "lxml" \
+    "sympy" \
+    "pyproj" \
+    "pytest" \
+    "shapely" \
+    "cartopy" \
     "progressbar2" \
-    "pillow ==5.0.0" \
+    "pillow" \
     "numpy >1.13" \
     "scipy" \
     "matplotlib" \
@@ -44,9 +44,9 @@ conda metapackage -c conda-forge -c e3sm -c cdat \
     "nb_conda" \
     "ipython" \
     "plotly" \
-    "bottleneck ==1.2.1" \
+    "bottleneck" \
     "hdf5 ==1.10.2" \
-    "netcdf4 ==1.3.1" \
+    "netcdf4 ==1.4.1" \
     "evtk ==1.1.1" \
     "f90nml" \
     "globus-cli" \

--- a/e3sm_unified_metapackage.bash
+++ b/e3sm_unified_metapackage.bash
@@ -52,7 +52,7 @@ conda metapackage -c conda-forge -c e3sm -c cdat \
     "globus-cli" \
     "globus-sdk" \
     "mpas_analysis ==1.0" \
-    "processflow ==2.0.2" \
+    "processflow ==2.0.4" \
     "tabulate" \
     "cmocean" \
     "gsw" \


### PR DESCRIPTION
Packages updated:
* processflow 2.0.4
* xarray 0.10.8
* dask 0.18.2
* netcdf4 1.4.1

Packages with newly unspecified versions:
* xml
* sympy
* pyproj
* pytest
* shapely
* cartopy
* bottleneck

Force installation of six and gcc-related libraries have been removed because this no longer appears to be necessary.