### PR TITLE
Update creation script

### DIFF
--- a/e3sm_supported_machines/create_new_env.bash
+++ b/e3sm_supported_machines/create_new_env.bash
@@ -30,7 +30,7 @@ check_env () {
     echo "  acme_diags failed"
     exit 1
   fi
-  if [[ $HOSTNAME == "blogin"* || $HOSTNAME == "rhea"* ]]; then
+  if [[ $HOSTNAME == "rhea"* ]]; then
     echo "  skipping processflow"
   else
     processflow -v

--- a/e3sm_supported_machines/create_new_env.bash
+++ b/e3sm_supported_machines/create_new_env.bash
@@ -4,41 +4,41 @@ check_env () {
   echo "Checking the environment $env_name"
   python -c "import vcs"
   if [ $? -eq 0 ]; then
+    echo "  vcs passed"
+  else
     echo "  vcs failed"
     exit 1
-  else
-    echo "  vcs passed"
   fi
   python -c "import mpas_analysis"
   if [ $? -eq 0 ]; then
+    echo "  mpas_analysis passed"
+  else
     echo "  mpas_analysis failed"
     exit 1
-  else
-    echo "  mpas_analysis passed"
   fi
   livv --version
   if [ $? -eq 0 ]; then
+    echo "  livvkit passed"
+  else
     echo "  livvkit failed"
     exit 1
-  else
-    echo "  livvkit passed"
   fi
   python -c "import acme_diags"
   if [ $? -eq 0 ]; then
+    echo "  acme_diags passed"
+  else
     echo "  acme_diags failed"
     exit 1
-  else
-    echo "  acme_diags passed"
   fi
   if [[ $HOSTNAME == "blogin"* || $HOSTNAME == "rhea"* ]]; then
     echo "  skipping processflow"
   else
-    processflow.py -v
+    processflow -v
     if [ $? -eq 0 ]; then
+      echo "  processflow passed"
+    else
       echo "  processflow failed"
       exit 1
-    else
-      echo "  processflow passed"
     fi
   fi
 }
@@ -135,8 +135,9 @@ do
         packages="$packages mesalib"
       fi
       env_name=e3sm_unified_${version}_py${python}_${x_or_nox}
-      conda remove -n $env_name -y --all
-      conda create -n $env_name -y $channels $packages
+      if [ ! -d $base_path/envs/$env_name ]; then
+        conda create -n $env_name -y $channels $packages
+      fi
 
       conda activate $env_name
       if [[ $HOSTNAME = "blogin"* ]]; then
@@ -182,4 +183,3 @@ else
   chmod -R g-w .
   chmod -R o-rwx .
 fi
-

--- a/e3sm_supported_machines/create_new_env.bash
+++ b/e3sm_supported_machines/create_new_env.bash
@@ -30,16 +30,12 @@ check_env () {
     echo "  acme_diags failed"
     exit 1
   fi
-  if [[ $HOSTNAME == "rhea"* ]]; then
-    echo "  skipping processflow"
+  processflow -v
+  if [ $? -eq 0 ]; then
+    echo "  processflow passed"
   else
-    processflow -v
-    if [ $? -eq 0 ]; then
-      echo "  processflow passed"
-    else
-      echo "  processflow failed"
-      exit 1
-    fi
+    echo "  processflow failed"
+    exit 1
   fi
 }
 


### PR DESCRIPTION
Swap order of error messages (oops!)

Also, skip creating environments if they exist (rather than deleting them).  This makes it easier to run the script a second time if it got interrupted or something small went wrong during the checking stage.