### PR TITLE
container definition and Travis CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+language: python
+
+sudo: required
+dist: trusty
+
+os: linux
+
+python:
+- '2.7'
+
+before_install:
+- sudo chmod u+x .travis/*.sh
+- "/bin/bash .travis/setup.sh"
+
+script:
+- bash .travis/build.sh e3sm-unified.def

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,36 @@
-language: python
-
-sudo: required
-dist: trusty
-
 os: linux
 
+language: go
+
+go:
+    - "1.11"
+
 python:
-- '2.7'
+    - "2.7"
+
+addons:
+  apt:
+    packages:
+      - flawfinder
+      - squashfs-tools
+      - uuid-dev
+      - libuuid1
+      - libffi-dev
+      - libssl-dev
+      - libssl1.0.0
+      - libarchive-dev
+      - libgpgme11-dev
+      - libseccomp-dev
+  homebrew:
+    packages:
+      - squashfs
+    update: true
+
+sudo: required
 
 before_install:
-- sudo chmod u+x .travis/*.sh
-- "/bin/bash .travis/setup.sh"
+    - sudo chmod u+x .travis/*.sh
+    - "/bin/bash .travis/setup.sh"
 
 script:
-- bash .travis/build.sh e3sm-unified.def
+    - bash .travis/build.sh e3sm-unified.def

--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+# always start unset
+unset abort_message
+
+# start with default of 0
+rc=0
+
+# Abort with message
+function abort () {
+    echo "$abort_message" >&2
+    exit $rc
+}
+
+# Check if abort is necessary, and if so do it
+function check_rc () {
+    if [ $# -gt 0 ];
+    then
+        abort_message="$1"
+    fi
+
+    if [ $rc -ne 0 ];
+    then
+        abort
+    fi
+
+    if [ $rc -eq 0 -a "$2" != "" ];
+    then
+        printf "$2"
+    fi
+}
+
+# Check if abort is necessary, fetching rc first
+function check_last_rc () {
+    # must be the first command of the function
+    rc=$?
+    check_rc "$@"
+}
+
+definitionfile=$1
+definition=`echo $definitionfile | sed 's/.def//'`
+imagefile="${definition}.simg"
+
+echo "Creating $imagefile using $definitionfile..."
+sudo singularity build $imagefile ${definitionfile}
+check_last_rc "Build of $definitionfile failed\n"
+echo
+
+# Example testing using run (you could also use test command)
+
+echo "Trying simple echo exec of $imagefile"
+singularity exec $imagefile echo "Working"
+check_last_rc "Basic exec failed\n"
+echo

--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -1,54 +1,12 @@
 #!/bin/bash
 
-# always start unset
-unset abort_message
-
-# start with default of 0
-rc=0
-
-# Abort with message
-function abort () {
-    echo "$abort_message" >&2
-    exit $rc
-}
-
-# Check if abort is necessary, and if so do it
-function check_rc () {
-    if [ $# -gt 0 ];
-    then
-        abort_message="$1"
-    fi
-
-    if [ $rc -ne 0 ];
-    then
-        abort
-    fi
-
-    if [ $rc -eq 0 -a "$2" != "" ];
-    then
-        printf "$2"
-    fi
-}
-
-# Check if abort is necessary, fetching rc first
-function check_last_rc () {
-    # must be the first command of the function
-    rc=$?
-    check_rc "$@"
-}
-
 definitionfile=$1
 definition=`echo $definitionfile | sed 's/.def//'`
 imagefile="${definition}.simg"
+testfile="${definition}-test.sh"
 
 echo "Creating $imagefile using $definitionfile..."
 sudo singularity build $imagefile ${definitionfile}
-check_last_rc "Build of $definitionfile failed\n"
-echo
 
-# Example testing using run (you could also use test command)
-
-echo "Trying simple echo exec of $imagefile"
-singularity exec $imagefile echo "Working"
-check_last_rc "Basic exec failed\n"
-echo
+echo "Running test"
+sudo singularity exec $imagefile /.${testfile}

--- a/.travis/setup.sh
+++ b/.travis/setup.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+sudo apt-get update
+
+sudo wget -O- http://neuro.debian.net/lists/xenial.us-ca.full | sudo tee /etc/apt/sources.list.d/neurodebian.sources.list && \
+    sudo apt-key adv --recv-keys --keyserver hkp://pool.sks-keyservers.net:80 0xA5D32F012649A5A9 && \
+    sudo apt-get update
+
+sudo apt-get install -y singularity-container
+
+echo "Singularity version"
+singularity --version
+echo

--- a/.travis/setup.sh
+++ b/.travis/setup.sh
@@ -1,12 +1,16 @@
 #!/bin/bash
 
-sudo apt-get update
+SINGULARITY_BASE="${GOPATH}/src/github.com/sylabs/singularity"
+export PATH="${GOPATH}/bin:${PATH}"
 
-sudo wget -O- http://neuro.debian.net/lists/xenial.us-ca.full | sudo tee /etc/apt/sources.list.d/neurodebian.sources.list && \
-    sudo apt-key adv --recv-keys --keyserver hkp://pool.sks-keyservers.net:80 0xA5D32F012649A5A9 && \
-    sudo apt-get update
+mkdir -p "${GOPATH}/src/github.com/sylabs"
+cd "${GOPATH}/src/github.com/sylabs"
 
-sudo apt-get install -y singularity-container
+git clone -b release-3.2 https://github.com/sylabs/singularity
+cd singularity
+./mconfig -v -p /usr/local
+make -j `nproc 2>/dev/null || echo 1` -C ./builddir all
+sudo make -C ./builddir install
 
 echo "Singularity version"
 singularity --version

--- a/e3sm-unified-test.sh
+++ b/e3sm-unified-test.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+# always start unset
+unset abort_message
+
+# start with default of 0
+rc=0
+
+# Abort with message
+function abort () {
+    echo "$abort_message" >&2
+    exit $rc
+}
+
+# Check if abort is necessary, and if so do it
+function check_rc () {
+    if [ $# -gt 0 ];
+    then
+        abort_message="$1"
+    fi
+
+    if [ $rc -ne 0 ];
+    then
+        abort
+    fi
+
+    if [ $rc -eq 0 -a "$2" != "" ];
+    then
+        printf "$2"
+    fi
+}
+
+# Check if abort is necessary, fetching rc first
+function check_last_rc () {
+    # must be the first command of the function
+    rc=$?
+    check_rc "$@"
+}
+
+echo "Loading conda profile"
+. /opt/conda/etc/profile.d/conda.sh
+
+echo "Activating e3sm conda environment"
+conda activate e3sm-unified-nox
+check_last_rc "Could not source e3sm-unified conda environment\n"
+
+# Try to run some simple help commands
+for cmd in "e3sm_diags" "processflow" "mpas_analysis"
+do
+    $cmd --help
+    check_last_rc "$cmd help failed\n"
+done

--- a/e3sm-unified.def
+++ b/e3sm-unified.def
@@ -1,0 +1,17 @@
+BootStrap: docker
+From: continuumio/miniconda
+
+%runscript
+    source ~/.bashrc
+    export PATH=/opt/conda/bin:${PATH}
+    conda activate e3sm-unified-nox
+
+%post
+    apt-get update && apt-get -y install wget build-essential
+    export PATH=/opt/conda/bin:${PATH}
+    conda create -n e3sm-unified-nox -c conda-forge -c e3sm -c cdat/label/v81 e3sm-unified mesalib
+    conda clean --all
+    echo ". /opt/conda/etc/profile.d/conda.sh" >> ~/.bashrc
+
+%labels
+    MAINTAINER sterlingbaldwin

--- a/e3sm-unified.def
+++ b/e3sm-unified.def
@@ -1,17 +1,18 @@
 BootStrap: docker
 From: continuumio/miniconda
 
+%files
+    e3sm-unified-test.sh /.e3sm-unified-test.sh
+
 %runscript
-    source ~/.bashrc
-    export PATH=/opt/conda/bin:${PATH}
+    #!/bin/bash
+    . /opt/conda/etc/profile.d/conda.sh
     conda activate e3sm-unified-nox
 
-%post
-    apt-get update && apt-get -y install wget build-essential
-    export PATH=/opt/conda/bin:${PATH}
-    conda create -n e3sm-unified-nox -c conda-forge -c e3sm -c cdat/label/v81 e3sm-unified mesalib
+%post -c /bin/bash
+    . /opt/conda/etc/profile.d/conda.sh
+    conda create -n e3sm-unified-nox -c conda-forge -c e3sm -c cdat/label/v81 python=2.7 e3sm-unified=1.2.5 mesalib
     conda clean --all
-    echo ". /opt/conda/etc/profile.d/conda.sh" >> ~/.bashrc
 
 %labels
     MAINTAINER sterlingbaldwin


### PR DESCRIPTION
This adds a Singularity container definition file and basic Travis CI config. The Travis CI build will attempt to create a container using the recommend install command
```
conda create -n e3sm-unified-nox -c conda-forge -c e3sm -c cdat/label/v81 e3sm-unified mesalib
```

If it builds, it then does a simple execution test. The next feature should be some tests using the [Singularity `test` command](https://www.sylabs.io/guides/3.2/user-guide/cli/singularity_test.html).