### PR TITLE
Update to 1.2.6

### DIFF
--- a/build.bash
+++ b/build.bash
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+#conda build -c conda-forge -c defaults -c e3sm -c cdat/label/v81 meta.yaml
+
+upload=True
+version=1.2.6
+pythons=(27 36 37)
+build=0
+
+if [ $upload == "True" ]
+then
+   for python in "${pythons[@]}"
+   do
+      anaconda upload -u e3sm /home/xylar/miniconda3/conda-bld/linux-64/e3sm-unified-${version}-py${python}_${build}.tar.bz2
+   done
+fi

--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -1,0 +1,10 @@
+channel_sources:
+  - conda-forge,defaults,cdat/label/v81,e3sm
+
+channel_targets:
+  - e3sm main
+
+python:
+   - 3.7
+   - 3.6
+   - 2.7

--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -1,9 +1,3 @@
-channel_sources:
-  - conda-forge,defaults,cdat/label/v81,e3sm
-
-channel_targets:
-  - e3sm main
-
 python:
    - 3.7
    - 3.6

--- a/e3sm-unified.def
+++ b/e3sm-unified.def
@@ -11,7 +11,7 @@ From: continuumio/miniconda
 
 %post -c /bin/bash
     . /opt/conda/etc/profile.d/conda.sh
-    conda create -n e3sm-unified-nox -c conda-forge -c e3sm -c cdat/label/v81 python=2.7 e3sm-unified=1.2.5 mesalib
+    conda create -n e3sm-unified-nox -c conda-forge -c e3sm -c cdat/label/v81 python=2.7 e3sm-unified=1.2.6 mesalib
     conda clean --all
 
 %labels

--- a/meta.yaml
+++ b/meta.yaml
@@ -4,14 +4,14 @@
 # Using the name variable with the URL in line 13 is convenient
 # when copying and pasting from another recipe, but not really needed.
 {% set name = "E3SM-Unified" %}
-{% set version = "1.2.5" %}
+{% set version = "1.2.6" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 build:
-  number: 1
+  number: 0
 
 requirements:
   host:
@@ -19,38 +19,50 @@ requirements:
   run:
     ### main packages ###
     - python
-    - cdat 8.1
-    - e3sm_diags 1.6.1 # [py27]
-    - nco 4.7.9
+    # channel: conda-forge
+    - nco 4.8.1
     - jupyter
     - ipython
     - globus-cli
-    - mpas-analysis 1.2.3
-    - processflow 2.2.0 # [linux and py27]
+    - mpas-analysis 1.2.4
     - ilamb 2.3.1 # [py27]
     - ilamb 2.4 # [py>=36]
     - livvkit 2.1.6
+    - geometric_features 0.1.1
+    - mpas_tools 0.0.3
+    - tempest-remap
+    # channel: cdat/label/v81
+    - cdat 8.1
+    # channel: e3sm
+    - e3sm_diags 1.6.1 # [py27]
+    - e3sm_diags 1.7.1 # [py>=36]
+    - processflow 2.2.1 # [linux and py27]
     - zstash 0.2.0 # [linux and py27]
+    - zstash 0.3.0 # [linux and py>=36]
     ### dependencies ###
+    # channel: cdat/lable/v81
     - cdat_info 8.1.1
+    - vcsaddons 8.1
+    - vtk-cdat 8.2.0rc2.8.1
+    - dv3d 8.1
+    - vcs 8.1
+    - wk 8.1
+    - e3sm_nex 1.0.0
+    # channel: conda-forge
     - cdms2 3.1.2
     - cdtime 3.1.2
     - cdutil 8.1
     - genutil 8.1.1
-    - vtk-cdat 8.2.0rc2.8.1
-    - dv3d 8.1
-    - vcs 8.1
-    - vcsaddons 8.1
-    - output_viewer 1.2.5
-    - wk 8.1
-    - thermo 8.1
-    - e3sm_nex 1.0.0
+    - output_viewer 1.3.0
     - cibots 0.3
-    - xarray 0.11.3
-    - dask 1.1.3
+    - xarray 0.11.3 # [py27]
+    - xarray 0.12.3 # [py>=36]
+    - dask 1.2.2 # [py27]
+    - dask 2.1.0 # [py>=36]
     - lxml
     - sympy
-    - pyproj
+    - pyproj >=1.9.6,<2.0.0
+    - proj4 >=5.2.0,<6.0.0
     - pytest
     - shapely
     - cartopy
@@ -65,11 +77,11 @@ requirements:
     - nb_conda_kernels
     - plotly
     - bottleneck
-    - hdf5 1.10.4
-    - netcdf4 1.4.2
+    - hdf5 1.10.5
+    - netcdf4 1.5.1.2
     - pyevtk 1.1.2
     - f90nml
-    - globus-sdk
+    - globus-sdk <=1.7.1
     - tabulate
     - cmocean
     - gsw
@@ -79,28 +91,31 @@ requirements:
     - shapely
     - eofs 1.3.1
     - pywavelets
-    # requirements because of old globus-cli used in processflow
-    - click >=6.6,<7.0 # [linux and py27]
-    - jmespath 0.9.2 # [linux and py27]
-    - configobj >=5.0.6,<6.0.0 # [linux and py27]
-    - requests>=2.0.0,<3.0.0 # [linux and py27]
-    - six>=1.10.0,<2.0.0 # [linux and py27]
-
+    # dependencies of the COMPASS test-case infrastructure in MPAS
+    - jigsaw
+    - metis
+    - pyflann
+    - scikit-image
+    - pyamg
+    - ffmpeg
 test:
+  requires:
+    - pytest
   imports:
     - mpas_analysis
-    - acme_diags # [py27]
+    - acme_diags
     - ILAMB
-    - zstash # [linux and py27]
+    - zstash # [linux]
     - IPython
     - globus_cli
     - livvkit
   commands:
+    - mpas_analysis --version
     - livv --version
     - export CDAT_ANONYMOUS_LOG=no; python -c "import vcs"
     - processflow -v # [linux and py27]
-    - e3sm_diags --help # [py27]
-    - zstash --help # [linux and py27]
+    - e3sm_diags --help
+    - zstash --help # [linux]
     - ilamb-fetch -h
     - ilamb-run -h
     - ilamb-table -h
@@ -111,7 +126,7 @@ test:
     - ipython -h
     - ipython3 -h # [py>=36]
     - globus --help
-
+    - GenerateCSMesh --res 64 --alt --file gravitySam.000000.3d.cubedSphere.g
 about:
   home: https://github.com/E3SM-Project/e3sm-unified
   summary: |


### PR DESCRIPTION
Update packages for v1.2.6

### Package changes
main packages:
* `e3sm_diags` - 1.6.1 (py2), 1.7.1 (py3)
* `geometric_features` - 0.1.1
* `mpas-analysis` - 1.2.4
* `mpas_tools` - 0.0.3
* `nco` - 4.8.1
* `zstash` - 0.2.0 (py2), 0.3.0 (py3)
* `processflow` - 2.2.1 (py2)

dependencies:
* `output_viewer` - 1.3.0
* `xarray` - 0.11.3 (py2), 0.12.3 (py3) 
* `dask` - 2.1.0
* `pyproj` - >=1.9.6,<2.0.0
* `proj4` - >=5.2.0,<6.0.0
* `hdf5` - 1.10.5
* `netcdf4` - 1.5.1.2
* `jigsaw` - nospec
* `metis` - nospec
* `pyflann` - nospec 
* `scikit-image` - nospec
* `pyamg` - nospec
* `ffmpeg` - nospec

`processflow` has been moved to its own separate environment because of incompatibilities between `ncl` and `basemap`, see #51 

closes #51 
