### PR TITLE
Turn off error checking during chown/chmod phase

### DIFF
--- a/e3sm_supported_machines/create_new_cime_env.bash
+++ b/e3sm_supported_machines/create_new_cime_env.bash
@@ -137,6 +137,9 @@ done
 # delete the tarballs and any unused packages
 conda clean -y -p -t
 
+# continue if errors happen from here on
+set +e
+
 echo "changing permissions on activation scripts"
 chown -R $USER:$group $activ_path/load_latest_cime_env*
 if [ $world_read == "True" ]; then

--- a/e3sm_supported_machines/create_new_env.bash
+++ b/e3sm_supported_machines/create_new_env.bash
@@ -304,6 +304,9 @@ done
 # delete the tarballs and any unused packages
 conda clean -y -p -t
 
+# continue if errors happen from here on
+set +e
+
 echo "changing permissions on activation scripts"
 chown -R "$USER":$group $activ_path/load_latest_e3sm_unified*
 if [ $world_read == "True" ]; then


### PR DESCRIPTION
This caused permissions not to get changed correctly on `cori` and maybe other machines.  As a result, users started installing their own packages!