### PR TITLE
Fix typos in create_new_env scrip

### DIFF
--- a/e3sm_supported_machines/create_new_cime_env.bash
+++ b/e3sm_supported_machines/create_new_cime_env.bash
@@ -30,7 +30,7 @@ default_python=3.7
 # immediately
 set -e
 
-world_read="False"
+world_read="True"
 channels="-c conda-forge -c defaults -c e3sm"
 
 # The rest of the script should not need to be modified
@@ -50,12 +50,10 @@ elif [[ $HOSTNAME = "rhea"* ]]; then
   base_path="/ccs/proj/cli900/sw/rhea/e3sm-unified/base"
   activ_path="/ccs/proj/cli900/sw/rhea/e3sm-unified"
   group="cli900"
-  world_read="True"
 elif [[ $HOSTNAME = "cooley"* ]]; then
   base_path="/lus/theta-fs0/projects/ccsm/acme/tools/e3sm-unified/base"
   activ_path="/lus/theta-fs0/projects/ccsm/acme/tools/e3sm-unified"
   group="ccsm"
-  world_read="True"
 elif [[ $HOSTNAME = "compy"* ]]; then
   base_path="/compyfs/software/e3sm-unified/base"
   activ_path="/compyfs/software/e3sm-unified"

--- a/e3sm_supported_machines/create_new_env.bash
+++ b/e3sm_supported_machines/create_new_env.bash
@@ -141,11 +141,11 @@ if [[ $HOSTNAME = "cori"* ]] || [[ $HOSTNAME = "dtn"* ]]; then
   base_path="/global/project/projectdirs/acme/software/anaconda_envs/cori/base"
   activ_path="/global/project/projectdirs/acme/software/anaconda_envs"
   group="acme"
-  module unlaod PrgEnv-intel
-  moudle load PrgEnv-gnu
+  module unload PrgEnv-intel
+  module load PrgEnv-gnu
   module unload craype-hugepages2M
   custom_script="echo module unlaod PrgEnv-intel"
-  custom_script="${custom_script}"$'\n'"module unlaod PrgEnv-intel"
+  custom_script="${custom_script}"$'\n'"module unload PrgEnv-intel"
   custom_script="${custom_script}"$'\n'"echo module load PrgEnv-gnu"
   custom_script="${custom_script}"$'\n'"module laod PrgEnv-gnu"
   custom_script="${custom_script}"$'\n'"echo module unload craype-hugepages2M"


### PR DESCRIPTION
Also, make world read the default when creating `cime_env`.  Since both scripts chown/chmod the whole set of envs for safety, it's important that they be consistent.