### PR TITLE
Pin numpy <1.18 based on incompatibility with cdms2

### DIFF
--- a/recipes/e3sm-unified/meta.yaml
+++ b/recipes/e3sm-unified/meta.yaml
@@ -6,7 +6,7 @@ package:
   version: {{ version }}
 
 build:
-  number: 1
+  number: 2
 
 requirements:
   host:
@@ -59,7 +59,7 @@ requirements:
     - cartopy
     - progressbar2
     - pillow
-    - numpy >1.13
+    - numpy >1.13,<1.18
     - scipy
     - matplotlib
     - basemap


### PR DESCRIPTION
This should be able to be relaxed in the next version of E3SM-Unified

closes #69 