### PR TITLE
Update to 1.3.1.2

### DIFF
--- a/e3sm-unified-test.sh
+++ b/e3sm-unified-test.sh
@@ -41,7 +41,7 @@ echo "Loading conda profile"
 . /opt/conda/etc/profile.d/conda.sh
 
 echo "Activating e3sm conda environment"
-conda activate e3sm-unified-nox
+conda activate e3sm-unified
 check_last_rc "Could not source e3sm-unified conda environment\n"
 
 # Try to run some simple help commands

--- a/e3sm-unified.def
+++ b/e3sm-unified.def
@@ -11,7 +11,7 @@ From: continuumio/miniconda3
 
 %post -c /bin/bash
     . /opt/conda/etc/profile.d/conda.sh
-    conda create -y -n e3sm-unified-nox -c conda-forge -c e3sm -c cdat/label/v82 python=3.7 "e3sm-unified=1.3.1.1=nompi_*" mesalib
+    conda create -y -n e3sm-unified -c conda-forge -c e3sm python=3.7 "e3sm-unified=1.3.1.2=nompi_*"
     conda clean --all
 
 %labels

--- a/e3sm-unified.def
+++ b/e3sm-unified.def
@@ -11,7 +11,7 @@ From: continuumio/miniconda3
 
 %post -c /bin/bash
     . /opt/conda/etc/profile.d/conda.sh
-    conda create -y -n e3sm-unified-nox -c conda-forge -c e3sm -c cdat/label/v82 python=3.7 "e3sm-unified=1.3.1=nompi_*" mesalib
+    conda create -y -n e3sm-unified-nox -c conda-forge -c e3sm -c cdat/label/v82 python=3.7 "e3sm-unified=1.3.1.1=nompi_*" mesalib
     conda clean --all
 
 %labels

--- a/e3sm_supported_machines/create_new_e3sm_unified_env.py
+++ b/e3sm_supported_machines/create_new_e3sm_unified_env.py
@@ -12,11 +12,11 @@ import progressbar
 def get_envs():
 
     envs = [{'suffix': '',
-             'version': '1.3.1.1',
+             'version': '1.3.1.2',
              'python': '3.7',
              'mpi': 'nompi'},
             {'suffix': '_mpich',
-             'version': '1.3.1.1',
+             'version': '1.3.1.2',
              'python': '3.7',
              'mpi': 'mpich'}]
 

--- a/e3sm_supported_machines/create_new_e3sm_unified_env.py
+++ b/e3sm_supported_machines/create_new_e3sm_unified_env.py
@@ -13,12 +13,12 @@ def get_envs():
 
     envs = [{'suffix': '',
              'version': '1.3.1.2',
-             'python': '3.7',
-             'mpi': 'nompi'},
-            {'suffix': '_mpich',
+             'python': '3.8',
+             'mpi': 'mpich'},
+            {'suffix': '_nompi',
              'version': '1.3.1.2',
-             'python': '3.7',
-             'mpi': 'mpich'}]
+             'python': '3.8',
+             'mpi': 'nompi'}]
 
     force_recreate = False
 
@@ -75,7 +75,7 @@ def check_env(base_path, env_name):
     activate = 'source {}/etc/profile.d/conda.sh; conda activate {}'.format(
         base_path, env_name)
 
-    imports = ['vcs', 'ILAMB', 'acme_diags', 'mpas_analysis', 'livvkit',
+    imports = ['ILAMB', 'acme_diags', 'mpas_analysis', 'livvkit',
                'IPython', 'globus_cli', 'zstash']
     for import_name in imports:
         command = '{}; python -c "import {}"'.format(activate, import_name)
@@ -150,7 +150,7 @@ def main():
             mpi_prefix = 'mpi_{}'.format(mpi)
 
         channels = '--override-channels -c conda-forge -c defaults ' \
-                   '-c e3sm -c cdat/label/v82'
+                   '-c e3sm'
         packages = 'python={} "e3sm-unified={}={}_*" mesalib'.format(
             python, version, mpi_prefix)
 
@@ -192,7 +192,7 @@ def main():
     subprocess.check_call(commands, executable='/bin/bash', shell=True)
 
     print('changing permissions on activation scripts')
-    activation_files = glob.glob('{}/load_latest_e3sm_unified*'.format(
+    activation_files = glob.glob('{}/load_*_e3sm_unified*'.format(
         activ_path))
 
     read_perm = stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IROTH

--- a/e3sm_supported_machines/create_new_e3sm_unified_env.py
+++ b/e3sm_supported_machines/create_new_e3sm_unified_env.py
@@ -149,9 +149,8 @@ def main():
         else:
             mpi_prefix = 'mpi_{}'.format(mpi)
 
-        channels = '--override-channels -c conda-forge -c defaults ' \
-                   '-c e3sm'
-        packages = 'python={} "e3sm-unified={}={}_*" mesalib'.format(
+        channels = '--override-channels -c conda-forge -c defaults -c e3sm'
+        packages = 'python={} "e3sm-unified={}={}_*"'.format(
             python, version, mpi_prefix)
 
         env_name = 'e3sm_unified_{}{}'.format(version, suffix)

--- a/e3sm_supported_machines/create_new_e3sm_unified_env.py
+++ b/e3sm_supported_machines/create_new_e3sm_unified_env.py
@@ -13,12 +13,12 @@ def get_envs():
 
     envs = [{'suffix': '',
              'version': '1.3.1.2',
-             'python': '3.8',
-             'mpi': 'mpich'},
-            {'suffix': '_nompi',
+             'python': '3.7',
+             'mpi': 'nompi'},
+            {'suffix': '_mpich',
              'version': '1.3.1.2',
-             'python': '3.8',
-             'mpi': 'nompi'}]
+             'python': '3.7',
+             'mpi': 'mpich'}]
 
     force_recreate = False
 
@@ -67,19 +67,19 @@ def get_host_info():
     return base_path, activ_path, group
 
 
-def check_env(base_path, env_name):
+def check_env(base_path, env_name, env):
     print("Checking the environment {}".format(env_name))
-    env = os.environ
-    env['CDAT_ANONYMOUS_LOG'] = 'no'
 
     activate = 'source {}/etc/profile.d/conda.sh; conda activate {}'.format(
         base_path, env_name)
 
-    imports = ['ILAMB', 'acme_diags', 'mpas_analysis', 'livvkit',
+    imports = ['acme_diags', 'mpas_analysis', 'livvkit',
                'IPython', 'globus_cli', 'zstash']
+    if env['mpi'] != 'nompi':
+        imports.append('ILAMB')
     for import_name in imports:
         command = '{}; python -c "import {}"'.format(activate, import_name)
-        test_command(command, env, import_name)
+        test_command(command, os.environ, import_name)
 
     commands = [['e3sm_diags', '--help'],
                 ['mpas_analysis', '-h'],
@@ -90,12 +90,12 @@ def check_env(base_path, env_name):
 
     for command in commands:
         command = '{}; {}'.format(activate, ' '.join(command))
-        test_command(command, env, command[0])
+        test_command(command, os.environ, command[0])
 
     command = '{}; GenerateCSMesh --res 64 --alt --file ' \
               'gravitySam.000000.3d.cubedSphere.g'.format(activate)
 
-    test_command(command, env, package='tempest-remap')
+    test_command(command, os.environ, package='tempest-remap')
 
 
 def test_command(command, env, package):
@@ -163,7 +163,7 @@ def main():
         else:
             print('{} already exists'.format(env_name))
 
-        check_env(base_path, env_name)
+        check_env(base_path, env_name, env)
 
         try:
             os.makedirs(activ_path)

--- a/e3sm_supported_machines/create_test_e3sm_unified_env.py
+++ b/e3sm_supported_machines/create_test_e3sm_unified_env.py
@@ -1,0 +1,259 @@
+#!/usr/bin/env python
+import subprocess
+import os
+import socket
+import glob
+import stat
+import grp
+import requests
+import progressbar
+
+
+def get_envs():
+
+    envs = [{'suffix': '',
+             'version': '1.3.1.2',
+             'python': '3.8',
+             'mpi': 'mpich'},
+            {'suffix': '_nompi',
+             'version': '1.3.1.2',
+             'python': '3.8',
+             'mpi': 'nompi'}]
+
+    force_recreate = False
+
+    return envs, force_recreate
+
+
+def get_host_info():
+    hostname = socket.gethostname()
+    if hostname.startswith('cori') or hostname.startswith('dtn'):
+        base_path = "/global/cfs/cdirs/e3sm/software/anaconda_envs/base"
+        activ_path = "/global/cfs/cdirs/e3sm/software/anaconda_envs"
+        group = "e3sm"
+    elif hostname.startswith('acme1') or hostname.startswith('aims4'):
+        base_path = "/usr/local/e3sm_unified/envs/base"
+        activ_path = "/usr/local/e3sm_unified/envs"
+        group = "climate"
+    elif hostname.startswith('blueslogin'):
+        base_path = "/lcrc/soft/climate/e3sm-unified/base"
+        activ_path = "/lcrc/soft/climate/e3sm-unified"
+        group = "climate"
+    elif hostname.startswith('rhea'):
+        base_path = "/ccs/proj/cli900/sw/rhea/e3sm-unified/base"
+        activ_path = "/ccs/proj/cli900/sw/rhea/e3sm-unified"
+        group = "cli900"
+    elif hostname.startswith('cooley'):
+        base_path = "/lus/theta-fs0/projects/ccsm/acme/tools/e3sm-unified/base"
+        activ_path = "/lus/theta-fs0/projects/ccsm/acme/tools/e3sm-unified"
+        group = "ccsm"
+    elif hostname.startswith('compy'):
+        base_path = "/share/apps/E3SM/conda_envs/base"
+        activ_path = "/share/apps/E3SM/conda_envs"
+        group = "users"
+    elif hostname.startswith('gr-fe') or hostname.startswith('wf-fe'):
+        base_path = "/usr/projects/climate/SHARED_CLIMATE/anaconda_envs/base"
+        activ_path = "/usr/projects/climate/SHARED_CLIMATE/anaconda_envs"
+        group = "climate"
+    elif hostname.startswith('burnham'):
+        base_path = "/home/xylar/Desktop/test_e3sm_unified/base"
+        activ_path = "/home/xylar/Desktop/test_e3sm_unified"
+        group = "xylar"
+    else:
+        raise ValueError(
+            "Unknown host name {}.  Add env_path and group for "
+            "this machine to the script.".format(hostname))
+
+    return base_path, activ_path, group
+
+
+def check_env(base_path, env_name):
+    print("Checking the environment {}".format(env_name))
+    env = os.environ
+    env['CDAT_ANONYMOUS_LOG'] = 'no'
+
+    activate = 'source {}/etc/profile.d/conda.sh; conda activate {}'.format(
+        base_path, env_name)
+
+    imports = ['ILAMB', 'acme_diags', 'mpas_analysis', 'livvkit',
+               'IPython', 'globus_cli', 'zstash']
+    for import_name in imports:
+        command = '{}; python -c "import {}"'.format(activate, import_name)
+        test_command(command, env, import_name)
+
+    commands = [['e3sm_diags', '--help'],
+                ['mpas_analysis', '-h'],
+                ['livv', '--version'],
+                ['globus', '--help'],
+                ['zstash', '--help'],
+                ['processflow', '-v']]
+
+    for command in commands:
+        command = '{}; {}'.format(activate, ' '.join(command))
+        test_command(command, env, command[0])
+
+    command = '{}; GenerateCSMesh --res 64 --alt --file ' \
+              'gravitySam.000000.3d.cubedSphere.g'.format(activate)
+
+    test_command(command, env, package='tempest-remap')
+
+
+def test_command(command, env, package):
+    try:
+        subprocess.check_call(command, env=env, executable='/bin/bash',
+                              shell=True)
+    except subprocess.CalledProcessError as e:
+        print('  {} failed'.format(package))
+        raise e
+    print('  {} passes'.format(package))
+
+
+def main():
+    # Modify the following list of dictionaries to choose which e3sm-unified
+    # version, python version, and which mpi variant (nompi, mpich or openmpi)
+    # to use.
+
+    envs, force_recreate = get_envs()
+
+    base_path, activ_path, group = get_host_info()
+
+    if not os.path.exists(base_path):
+        miniconda = 'Miniconda3-latest-Linux-x86_64.sh'
+        url = 'https://repo.continuum.io/miniconda/{}'.format(miniconda)
+        r = requests.get(url)
+        with open(miniconda, 'wb') as outfile:
+            outfile.write(r.content)
+
+        command = '/bin/bash {} -b -p {}'.format(miniconda, base_path)
+        subprocess.check_call(command, executable='/bin/bash', shell=True)
+        os.remove(miniconda)
+
+    print('Doing initial setup')
+    activate = 'source {}/etc/profile.d/conda.sh; conda activate'.format(
+        base_path)
+
+    commands = '{}; conda config --add channels conda-forge; ' \
+               'conda config --set channel_priority strict; ' \
+               'conda update -y --all'.format(activate)
+
+    subprocess.check_call(commands, executable='/bin/bash', shell=True)
+    print('done')
+
+    for env in envs:
+        version = env['version']
+        suffix = env['suffix']
+        python = env['python']
+        mpi = env['mpi']
+        if mpi == 'nompi':
+            mpi_prefix = 'nompi'
+        else:
+            mpi_prefix = 'mpi_{}'.format(mpi)
+
+        channels = '--override-channels --use-local -c conda-forge -c defaults ' \
+                   '-c e3sm'
+        packages = 'python={} "e3sm-unified={}={}_*" mesalib'.format(
+            python, version, mpi_prefix)
+
+        env_name = 'test_e3sm_unified_{}{}'.format(version, suffix)
+        if not os.path.exists('{}/envs/{}'.format(base_path, env_name)) \
+                or force_recreate:
+            print('creating {}'.format(env_name))
+            commands = '{}; conda create -y -n {} {} {}'.format(
+                activate, env_name, channels, packages)
+            subprocess.check_call(commands, executable='/bin/bash', shell=True)
+        else:
+            print('{} already exists'.format(env_name))
+
+        check_env(base_path, env_name)
+
+        try:
+            os.makedirs(activ_path)
+        except FileExistsError:
+            pass
+
+        for ext in ['sh', 'csh']:
+            script = []
+            if ext == 'sh':
+                script.extend(['if [ -x "$(command -v module)" ] ; then\n',
+                               '  module unload python\n',
+                               'fi\n'])
+            script.append('source {}/etc/profile.d/conda.{}\n'.format(
+                base_path, ext))
+            script.append('conda activate {}\n'.format(env_name))
+
+            file_name = '{}/load_test_e3sm_unified{}.{}'.format(
+                activ_path, suffix, ext)
+            if os.path.exists(file_name):
+                os.remove(file_name)
+            with open(file_name, 'w') as f:
+                f.writelines(script)
+
+    commands = '{}; conda clean -y -p -t'.format(activate)
+    subprocess.check_call(commands, executable='/bin/bash', shell=True)
+
+    print('changing permissions on activation scripts')
+    activation_files = glob.glob('{}/load_*_e3sm_unified*'.format(
+        activ_path))
+
+    read_perm = stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IROTH
+    exec_perm = (stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR |
+                 stat.S_IRGRP | stat.S_IXGRP |
+                 stat.S_IROTH | stat.S_IXOTH)
+
+    for file_name in activation_files:
+        os.chmod(file_name, read_perm)
+
+    print('changing permissions on environments')
+
+    uid = os.getuid()
+    gid = grp.getgrnam(group).gr_gid
+
+    files_and_dirs = []
+    for root, dirs, files in os.walk(base_path):
+        files_and_dirs.extend(dirs)
+        files_and_dirs.extend(files)
+
+    widgets = [progressbar.Percentage(), ' ', progressbar.Bar(),
+               ' ', progressbar.ETA()]
+    bar = progressbar.ProgressBar(widgets=widgets,
+                                  maxval=len(files_and_dirs)).start()
+    progress = 0
+    for root, dirs, files in os.walk(base_path):
+        for directory in dirs:
+            progress += 1
+            bar.update(progress)
+
+            directory = os.path.join(root, directory)
+            try:
+                os.chown(directory, uid, gid)
+                os.chmod(directory, exec_perm)
+            except OSError:
+                continue
+
+        for file_name in files:
+            progress += 1
+            bar.update(progress)
+            file_name = os.path.join(root, file_name)
+            try:
+                perm = os.stat(file_name).st_mode
+            except OSError:
+                continue
+
+            if perm & stat.S_IXUSR:
+                # executable, so make sure others can execute it
+                perm = exec_perm
+            else:
+                perm = read_perm
+
+            try:
+                os.chown(file_name, uid, gid)
+                os.chmod(file_name, perm)
+            except OSError:
+                continue
+
+    bar.finish()
+    print('  done.')
+
+
+if __name__ == '__main__':
+    main()

--- a/e3sm_supported_machines/create_test_e3sm_unified_env.py
+++ b/e3sm_supported_machines/create_test_e3sm_unified_env.py
@@ -20,7 +20,7 @@ def get_envs():
              'python': '3.8',
              'mpi': 'nompi'}]
 
-    force_recreate = False
+    force_recreate = True
 
     return envs, force_recreate
 
@@ -150,7 +150,7 @@ def main():
             mpi_prefix = 'mpi_{}'.format(mpi)
 
         channels = '--override-channels -c conda-forge -c defaults -c e3sm'
-        packages = 'python={} "e3sm-unified={}={}_*" mesalib'.format(
+        packages = 'python={} "e3sm-unified={}={}_*"'.format(
             python, version, mpi_prefix)
 
         env_name = 'test_e3sm_unified_{}{}'.format(version, suffix)

--- a/e3sm_supported_machines/create_test_e3sm_unified_env.py
+++ b/e3sm_supported_machines/create_test_e3sm_unified_env.py
@@ -149,8 +149,7 @@ def main():
         else:
             mpi_prefix = 'mpi_{}'.format(mpi)
 
-        channels = '--override-channels --use-local -c conda-forge -c defaults ' \
-                   '-c e3sm'
+        channels = '--override-channels -c conda-forge -c defaults -c e3sm'
         packages = 'python={} "e3sm-unified={}={}_*" mesalib'.format(
             python, version, mpi_prefix)
 

--- a/recipes/e3sm-unified/build_and_upload.bash
+++ b/recipes/e3sm-unified/build_and_upload.bash
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-conda build --override-channels -c conda-forge -c defaults -c e3sm -c cdat/label/v82 .
+conda build --override-channels -c conda-forge -c defaults -c e3sm .
 
 upload=False
 

--- a/recipes/e3sm-unified/conda_build_config.yaml
+++ b/recipes/e3sm-unified/conda_build_config.yaml
@@ -1,6 +1,7 @@
 python:
   - 3.6
   - 3.7
+  - 3.8
 
 mpi:
   - nompi

--- a/recipes/e3sm-unified/meta.yaml
+++ b/recipes/e3sm-unified/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "E3SM-Unified" %}
-{% set version = "1.3.1.1" %}
+{% set version = "1.3.1.2" %}
 {% set build = 0 %}
 
 package:
@@ -94,7 +94,11 @@ requirements:
     - scikit-image
     - eofs 1.3.1
     - pywavelets
-    - mpi4py  # [mpi != 'nompi']
+    # mpi4py is a dependency of ilamb, so always needed.  Since it requires
+    # some mpi to be installed, we want mpich, since this works with e3sm_diags
+    # on more systems
+    - mpi4py
+    - mpich  # [mpi == 'nompi']
     - pyremap
     - esmf 8.0.1 {{ mpi_prefix }}_*
     - openssh  # [mpi == 'openmpi']

--- a/recipes/e3sm-unified/meta.yaml
+++ b/recipes/e3sm-unified/meta.yaml
@@ -33,25 +33,19 @@ requirements:
     - jupyter
     - ipython
     - globus-cli
-    - mpas-analysis 1.2.7
+    - mpas-analysis 1.2.8
     - ilamb 2.5
     - livvkit 3.0.0
-    - geometric_features 0.1.10
-    - mpas_tools 0.0.10
-    # does not support hdf5 1.10.6
+    - geometric_features 0.1.11
+    - mpas_tools 0.0.13
+    - e3sm_diags 2.2.0
+    # ncl requires the latest proj and libgdal but these conflict with rasterio
     # - ncl >=6.6.2
     # channel: e3sm
-    - e3sm_diags 2.1.1
     - processflow 2.2.4  # [linux]
-    - compass 0.1.8 {{ mpi_prefix }}_*
+    - compass 0.1.11 {{ mpi_prefix }}_*
     - zstash 0.4.2  # [linux]
     ### dependencies ###
-    # channel: cdat/lable/v82
-    - vcs 8.2
-    - vcsaddons 8.2
-    - vtk-cdat 8.2.0.8.2
-    - dv3d 8.2
-    - wk 8.2
     # channel: conda-forge
     - {{ mpi }}  # [mpi != 'nompi']
     - cdat_info 8.2
@@ -67,6 +61,7 @@ requirements:
     - lxml
     - sympy
     - pyproj 2.6.1.post1
+    # can't bump until rasterio issue gets fixed
     - proj 7.0.0
     - pytest
     - shapely
@@ -117,7 +112,6 @@ test:
   commands:
     - mpas_analysis --version
     - livv --version
-    - export CDAT_ANONYMOUS_LOG=no; python -c "import vcs"
     - processflow -v  # [linux]
     - e3sm_diags --help
     - zstash --help  # [linux]

--- a/recipes/e3sm-unified/meta.yaml
+++ b/recipes/e3sm-unified/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "E3SM-Unified" %}
 {% set version = "1.3.1.2" %}
-{% set build = 1 %}
+{% set build = 2 %}
 
 package:
   name: {{ name|lower }}

--- a/recipes/e3sm-unified/meta.yaml
+++ b/recipes/e3sm-unified/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "E3SM-Unified" %}
 {% set version = "1.3.1.2" %}
-{% set build = 0 %}
+{% set build = 1 %}
 
 package:
   name: {{ name|lower }}
@@ -29,12 +29,12 @@ requirements:
     ### main packages ###
     - python
     # channel: conda-forge
-    - nco 4.9.3
+    - nco 4.9.4
     - jupyter
     - ipython
     - globus-cli
     - mpas-analysis 1.2.8
-    - ilamb 2.5
+    - ilamb 2.5  # [mpi != 'nompi']
     - livvkit 3.0.0
     - geometric_features 0.1.11
     - mpas_tools 0.0.13
@@ -89,11 +89,7 @@ requirements:
     - scikit-image
     - eofs 1.3.1
     - pywavelets
-    # mpi4py is a dependency of ilamb, so always needed.  Since it requires
-    # some mpi to be installed, we want mpich, since this works with e3sm_diags
-    # on more systems
-    - mpi4py
-    - mpich  # [mpi == 'nompi']
+    - mpi4py  # [mpi != 'nompi']
     - pyremap
     - esmf 8.0.1 {{ mpi_prefix }}_*
     - openssh  # [mpi == 'openmpi']
@@ -104,7 +100,7 @@ test:
   imports:
     - mpas_analysis
     - acme_diags
-    - ILAMB
+    - ILAMB  # [mpi != 'nompi']
     - zstash  # [linux]
     - IPython
     - globus_cli
@@ -115,9 +111,9 @@ test:
     - processflow -v  # [linux]
     - e3sm_diags --help
     - zstash --help  # [linux]
-    - ilamb-fetch -h
-    - ilamb-run -h
-    - ilamb-table -h
+    - ilamb-fetch -h  # [mpi != 'nompi']
+    - ilamb-run -h  # [mpi != 'nompi']
+    - ilamb-table -h  # [mpi != 'nompi']
     - ncks --help
     - ncap2 --help
     - jupyter --help

--- a/recipes/e3sm-unified/meta.yaml
+++ b/recipes/e3sm-unified/meta.yaml
@@ -29,7 +29,7 @@ requirements:
     ### main packages ###
     - python
     # channel: conda-forge
-    - nco 4.9.4
+    - nco 4.9.5
     - jupyter
     - ipython
     - globus-cli

--- a/recipes/e3sm-unified/meta.yaml
+++ b/recipes/e3sm-unified/meta.yaml
@@ -44,7 +44,7 @@ requirements:
     - e3sm_diags 2.1.1
     - processflow 2.2.4  # [linux]
     - compass 0.1.8 {{ mpi_prefix }}_*
-    - zstash 0.4.1  # [linux]
+    - zstash 0.4.2  # [linux]
     ### dependencies ###
     # channel: cdat/lable/v82
     - vcs 8.2


### PR DESCRIPTION
Change `mpi4py` to be included explicitly in `nompi` build (it was there anyway because of `ilamb`) and make sure `mpi` is `mpich` except for the explicit `openmpi` build, since this is what works well with `e3sm_diags`.