### PR TITLE
Fix permissions masking in deployment scripts

### DIFF
--- a/e3sm_supported_machines/create_new_e3sm_unified_env.py
+++ b/e3sm_supported_machines/create_new_e3sm_unified_env.py
@@ -234,8 +234,8 @@ def main():
 
             perm = dir_stat.st_mode & mask
 
-            if perm == exec_perm and dir_stat.uid == new_uid and \
-                    dir_stat.gid == new_gid:
+            if perm == exec_perm and dir_stat.st_uid == new_uid and \
+                    dir_stat.st_gid == new_gid:
                 continue
 
             try:
@@ -261,8 +261,8 @@ def main():
             else:
                 new_perm = read_perm
                 
-            if perm == new_perm and file_stat.uid == new_uid and \
-                    file_stat.gid == new_gid:
+            if perm == new_perm and file_stat.st_uid == new_uid and \
+                    file_stat.st_gid == new_gid:
                 continue
 
             try:

--- a/e3sm_supported_machines/create_new_e3sm_unified_env.py
+++ b/e3sm_supported_machines/create_new_e3sm_unified_env.py
@@ -232,7 +232,7 @@ def main():
             except OSError:
                 continue
 
-            perm = file_stat.st_mode & mask
+            perm = dir_stat.st_mode & mask
 
             if perm == exec_perm and dir_stat.uid == new_uid and \
                     dir_stat.gid == new_gid:

--- a/e3sm_supported_machines/create_new_e3sm_unified_env.py
+++ b/e3sm_supported_machines/create_new_e3sm_unified_env.py
@@ -199,6 +199,8 @@ def main():
     exec_perm = (stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR |
                  stat.S_IRGRP | stat.S_IXGRP |
                  stat.S_IROTH | stat.S_IXOTH)
+    
+    mask = stat.S_IRWXU | stat.S_IRWXG | stat.S_IRWXO
 
     for file_name in activation_files:
         os.chmod(file_name, read_perm)
@@ -230,7 +232,9 @@ def main():
             except OSError:
                 continue
 
-            if dir_stat.st_mode == exec_perm and dir_stat.uid == new_uid and \
+            perm = file_stat.st_mode & mask
+
+            if perm == exec_perm and dir_stat.uid == new_uid and \
                     dir_stat.gid == new_gid:
                 continue
 
@@ -249,7 +253,7 @@ def main():
             except OSError:
                 continue
                 
-            perm = file_stat.st_mode
+            perm = file_stat.st_mode & mask
 
             if perm & stat.S_IXUSR:
                 # executable, so make sure others can execute it


### PR DESCRIPTION
This merge updates how ownership and permissions are changed in the deployment scripts.  #80 didn't quite get things right because there are other parts to the `st_mode` flag besides owner, group and user permissions, so that flag needs to be masked only to the parts relevant to file permissions to see if the permissions are already correct.

By checking if permissions are already correct, hours of time needlessly updating permissions should be saved in the future.  Compy is the machine where this is the biggest problem. With these changes, modifying permissions should happen in 2 hours instead of 16 or more.