### PR TITLE
Remove cdat label from install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,13 +14,12 @@ Users can create a new anaconda environment either with or without x-windows sup
 within CDAT packages (if you do not plan to use CDAT or e3sm_diags, either version is
 fine).  To create an E3SM-Unified environment with x-windows support under CDAT, use:
 ```
-conda create -n e3sm-unified-x -c conda-forge -c defaults -c e3sm -c cdat/label/v82 \
-    e3sm-unified python=3.7
+conda create -n e3sm-unified-x -c conda-forge -c defaults -c e3sm python=3.7 e3sm-unified
 ```
 To create and environment without x-windows under CDAT, use:
 ```
-conda create -n e3sm-unified-nox -c conda-forge -c defaults -c e3sm -c cdat/label/v82 \
-    e3sm-unified mesalib python=3.7
+conda create -n e3sm-unified-nox -c conda-forge -c defaults -c e3sm \
+    python=3.7 e3sm-unified mesalib
 ```
 
  The following packages are only available for linux and not OSX:


### PR DESCRIPTION
We no longer require packages from `cdat`.