### PR TITLE
Do not remove `esmf` from the conda environment 

### DIFF
--- a/e3sm_supported_machines/bootstrap.py
+++ b/e3sm_supported_machines/bootstrap.py
@@ -140,7 +140,7 @@ def build_env(is_test, recreate, compiler, mpi, conda_mpi, version,
         check_call(commands)
 
         if conda_mpi == 'hpc':
-            remove_packages = 'esmf nco tempest-remap'
+            remove_packages = 'nco tempest-remap'
             # remove conda-forge versions so we're sure to use Spack versions
             commands = f'{activate_base}; conda remove -y --force ' \
                        f'-n {env_name} {remove_packages}'

--- a/e3sm_supported_machines/cori-knl.cfg
+++ b/e3sm_supported_machines/cori-knl.cfg
@@ -1,4 +1,0 @@
-[spack_specs]
-
-# the version of ESMF
-esmf =


### PR DESCRIPTION
It is needed by `emspy`, which is needed by `cdms2`, which is needed by `e3sm_diags`.

E3SM-Unified 1.6.0 has been re-deployed on:
- [x] Anvil
- [x] Badger
- [x] Chrysalis
- [x] Compy
- [x] Cori-Haswell