### PR TITLE
Update to E3SM-Unified v1.7.1

### DIFF
--- a/e3sm_supported_machines/default.cfg
+++ b/e3sm_supported_machines/default.cfg
@@ -32,10 +32,10 @@ mpi4py = 3.1.3
 [spack_specs]
 
 esmf = esmf@8.2.0+mpi+netcdf~pio+pnetcdf
-hdf5 = hdf5@1.12.1+cxx+fortran+hl+mpi+shared
-moab = moab@5.3.1+mpi+hdf5+netcdf+pnetcdf+metis+parmetis+tempest
+hdf5 = hdf5@1.12.2+cxx+fortran+hl+mpi+shared
+moab = moab@5.4.0+mpi+hdf5+netcdf+pnetcdf+metis+parmetis+tempest
 nco = nco@5.1.0+openmp
 netcdf_c = netcdf-c@4.8.1+mpi~parallel-netcdf
 netcdf_fortran = netcdf-fortran@4.5.4
 tempestextremes = tempestextremes@2.2.1+mpi
-tempestremap = tempestremap@2.1.1
+tempestremap = tempestremap@2.1.6

--- a/e3sm_supported_machines/shared.py
+++ b/e3sm_supported_machines/shared.py
@@ -14,7 +14,7 @@ except ImportError:
 def parse_args(bootstrap):
     parser = argparse.ArgumentParser(
         description='Deploy E3SM-Unified')
-    parser.add_argument("--version", dest="version", default="1.7.0",
+    parser.add_argument("--version", dest="version", default="1.7.1",
                         help="The version of E3SM-Unified to deploy")
     parser.add_argument("--conda", dest="conda_base",
                         help="Path for the  conda base")

--- a/recipes/e3sm-unified/meta.yaml
+++ b/recipes/e3sm-unified/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "E3SM-Unified" %}
-{% set version = "1.7.0" %}
+{% set version = "1.7.1" %}
 {% set build = 0 %}
 
 package:
@@ -39,12 +39,12 @@ requirements:
     - jupyter
     - livvkit 3.0.1
     - mache 1.5.0
-    - moab 5.3.1 {{ mpi_prefix }}_tempest_*  # [mpi != 'hpc']
-    - mpas-analysis 1.7.0
-    - mpas_tools 0.14.0
+    - moab 5.4.0 {{ mpi_prefix }}_tempest_*  # [mpi != 'hpc']
+    - mpas-analysis 1.7.2
+    - mpas_tools 0.15.0
     - nco 5.1.0  # [mpi != 'hpc']
     - pcmdi_metrics 2.3.1
-    - tempest-remap 2.1.1  # [mpi != 'hpc']
+    - tempest-remap 2.1.6  # [mpi != 'hpc']
     - tempest-extremes 2.2.1 {{ mpi_prefix }}_*  # [mpi != 'hpc']
     - xcdat 0.3.0
     - zstash 1.2.1  # [linux]
@@ -68,7 +68,7 @@ requirements:
     - genutil 8.2.1
     - globus-sdk
     - gsw
-    - hdf5 1.12.1 {{ mpi_prefix }}_*
+    - hdf5 1.12.2 {{ mpi_prefix }}_*
     - ipygany
     - libnetcdf 4.8.1 {{ mpi_prefix }}_*
     - lxml
@@ -78,16 +78,16 @@ requirements:
     - nb_conda
     - nb_conda_kernels
     - ncview 2.1.8
-    - netcdf4 1.5.8 nompi_*
+    - netcdf4 1.6.1 nompi_*
     - numpy >1.13
     - openssh  # [mpi == 'openmpi']
     - output_viewer 1.3.3
     - pillow
     - plotly
     - progressbar2
-    - proj 9.0.0
+    - proj 9.1.0
     - pyevtk
-    - pyproj 3.3.1
+    - pyproj 3.4.0
     - pyremap
     - pytest
     - pywavelets
@@ -96,7 +96,7 @@ requirements:
     - shapely
     - sympy >=0.7.6
     - tabulate
-    - xarray 2022.3.0
+    - xarray 2022.6.0
     - xesmf
 
     # addition ilamb 2.6 dependencies, for system MPI builds


### PR DESCRIPTION
This version includes:
* MPAS-Analysis 1.7.2, with important bug fixes related to CF-compliant output in the latest E3SM simulations
* MOAB 5.4.0
* TempestRemap 2.1.6


## Deployment
Deployed on:
- [x] Andes
- [x] Anvil
- [x] Chrysalis
- [x] Compy
- [x] Cori-Haswell
- [x] Cori-KNL