### PR TITLE
Update to v1.8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# e3sm-unified
+# E3SM-Unified
 
 A metapackage for a unified anaconda environment for analyzing results from
 the Energy Exascale Earth System Model (E3SM).
 
-E3SM-Unified currently supports linux and OSX, and python >= 3.8.   A Windows 
-version is not available and the development of one is not planned.
+E3SM-Unified currently supports linux and OSX, and python >= 3.8 and < 3.11.
+A Windows  version is not available and the development of one is not planned.
 
 Users can create a new anaconda environment either with or without MPI support
 from conda.  To create the latest version of the E3SM-Unified environment with 
@@ -13,15 +13,18 @@ MPI support from the `mpich` package, use:
 conda config --add channels conda-forge
 conda config --set channel_priority strict
 conda create -n e3sm-unified-mpich -c conda-forge -c defaults -c e3sm \
-    python=3.9 "e3sm-unified=*=mpi_mpich_*"
+    python=3.10 "e3sm-unified=*=mpi_mpich_*"
 ```
 To create and environment without MPI, use:
 ```
 conda config --add channels conda-forge
 conda config --set channel_priority strict
 conda create -n e3sm-unified-nompi -c conda-forge -c defaults -c e3sm \
-    python=3.9 "e3sm-unified=*=nompi_*"
+    python=3.10 "e3sm-unified=*=nompi_*"
 ```
 
  The following package is only available for linux and not OSX:
  - zstash
+
+For the full list of packages in the current version of the metapackages, see:
+https://github.com/E3SM-Project/e3sm-unified/blob/master/recipes/e3sm-unified/meta.yaml

--- a/e3sm_supported_machines/bootstrap.py
+++ b/e3sm_supported_machines/bootstrap.py
@@ -123,11 +123,11 @@ def build_env(is_test, recreate, compiler, mpi, conda_mpi, version,
 
     packages = f'python={python} pip'
 
-    base_activation_script = os.path.abspath(
-        f'{conda_base}/etc/profile.d/conda.sh')
+    source_activation_scripts = \
+        f'source {conda_base}/etc/profile.d/conda.sh; ' \
+        f'source {conda_base}/etc/profile.d/mamba.sh'
 
-    activate_env = \
-        'source {}; conda activate {}'.format(base_activation_script, env_name)
+    activate_env = f'{source_activation_scripts}; conda activate {env_name}'
 
     if not os.path.exists(env_path) or recreate:
         print(f'creating {env_name}')
@@ -330,10 +330,13 @@ def main():
         is_test = not config.getboolean('e3sm_unified', 'release')
 
     conda_base = get_conda_base(args.conda_base, config, shared=True)
-    base_activation_script = os.path.abspath(
-        f'{conda_base}/etc/profile.d/conda.sh')
+    conda_base = os.path.abspath(conda_base)
 
-    activate_base = f'source {base_activation_script}; conda activate'
+    source_activation_scripts = \
+        f'source {conda_base}/etc/profile.d/conda.sh; ' \
+        f'source {conda_base}/etc/profile.d/mamba.sh'
+
+    activate_base = f'{source_activation_scripts}; conda activate'
 
     # install miniconda if needed
     install_miniconda(conda_base, activate_base)

--- a/e3sm_supported_machines/bootstrap.py
+++ b/e3sm_supported_machines/bootstrap.py
@@ -79,7 +79,7 @@ def get_env_setup(args, config, machine):
 
 def build_env(is_test, recreate, compiler, mpi, conda_mpi, version,
               python, conda_base, activ_suffix, env_suffix, activate_base,
-              local_conda_build, nco_dev):
+              local_conda_build, config):
 
     if compiler is not None:
         build_dir = f'build{activ_suffix}'
@@ -110,12 +110,20 @@ def build_env(is_test, recreate, compiler, mpi, conda_mpi, version,
         mpi_prefix = f'mpi_{conda_mpi}'
 
     if is_test:
+
+        nco_spec = config.get('spack_specs', 'nco')
+        nco_dev = ('alpha' in nco_spec or 'beta' in nco_spec)
+        moab_spec = config.get('spack_specs', 'moab')
+        moab_dev = ('rc' in moab_spec.lower())
+
         channels = '--override-channels'
         if local_conda_build is not None:
             channels = f'{channels} -c {local_conda_build}'
 
         if nco_dev:
             channels = f'{channels} -c conda-forge/label/nco_dev'
+        if moab_dev:
+            channels = f'{channels} -c conda-forge/label/moab_dev'
         channels = f'{channels} -c conda-forge/label/e3sm_dev ' \
                    f'-c conda-forge -c defaults -c e3sm/label/e3sm_dev -c e3sm'
     else:
@@ -347,16 +355,13 @@ def main():
     if machine is None:
         compiler = None
 
-    nco_spec = config.get('spack_specs', 'nco')
-    nco_dev = ('alpha' in nco_spec or 'beta' in nco_spec)
-
     nompi_compiler = None
     nompi_suffix = '_nompi'
     # first, make nompi environment
     env_path, env_nompi, _, _, _ = build_env(
         is_test, recreate, nompi_compiler, mpi, 'nompi', version,
         python, conda_base, nompi_suffix, nompi_suffix, activate_base,
-        args.local_conda_build, nco_dev)
+        args.local_conda_build, config)
 
     if not is_test:
         # make a symlink to the environment
@@ -366,7 +371,7 @@ def main():
     env_path, env_name, activate_env, channels, spack_env = build_env(
         is_test, recreate, compiler, mpi, conda_mpi, version,
         python, conda_base, activ_suffix, env_suffix, activate_base,
-        args.local_conda_build, nco_dev)
+        args.local_conda_build, config)
 
     sys_info = dict(modules=[],
                     env_vars=['export HDF5_USE_FILE_LOCKING=FALSE'])

--- a/e3sm_supported_machines/default.cfg
+++ b/e3sm_supported_machines/default.cfg
@@ -22,7 +22,7 @@ ilamb = 2.6
 
 # the version of mache to use during deployment (should match the version used
 # in the package itself)
-mache = 1.8.0rc1
+mache = 1.8.0rc2
 
 # the version of mpi4py to build if using system compilers
 mpi4py = 3.1.3

--- a/e3sm_supported_machines/default.cfg
+++ b/e3sm_supported_machines/default.cfg
@@ -22,7 +22,7 @@ ilamb = 2.6
 
 # the version of mache to use during deployment (should match the version used
 # in the package itself)
-mache = 1.8.0rc2
+mache = 1.9.0rc2
 
 # the version of mpi4py to build if using system compilers
 mpi4py = 3.1.3
@@ -34,7 +34,7 @@ mpi4py = 3.1.3
 esmf = esmf@8.2.0+mpi+netcdf~pio+pnetcdf
 hdf5 = hdf5@1.12.2+cxx+fortran+hl+mpi+shared
 moab = moab@5.4.0+mpi+hdf5+netcdf+pnetcdf+metis+parmetis+tempest
-nco = nco@5.1.1+openmp
+nco = nco@5.1.2-beta01+openmp
 netcdf_c = netcdf-c@4.8.1+mpi~parallel-netcdf
 netcdf_fortran = netcdf-fortran@4.5.4
 tempestextremes = tempestextremes@2.2.1+mpi

--- a/e3sm_supported_machines/default.cfg
+++ b/e3sm_supported_machines/default.cfg
@@ -22,7 +22,7 @@ ilamb = 2.6
 
 # the version of mache to use during deployment (should match the version used
 # in the package itself)
-mache = 1.7.0
+mache = 1.8.0rc1
 
 # the version of mpi4py to build if using system compilers
 mpi4py = 3.1.3

--- a/e3sm_supported_machines/default.cfg
+++ b/e3sm_supported_machines/default.cfg
@@ -22,7 +22,7 @@ ilamb = 2.6
 
 # the version of mache to use during deployment (should match the version used
 # in the package itself)
-mache = 1.9.0rc2
+mache = 1.9.0rc3
 
 # the version of mpi4py to build if using system compilers
 mpi4py = 3.1.3
@@ -33,7 +33,7 @@ mpi4py = 3.1.3
 
 esmf = esmf@8.2.0+mpi+netcdf~pio+pnetcdf
 hdf5 = hdf5@1.12.2+cxx+fortran+hl+mpi+shared
-moab = moab@5.4.0+mpi+hdf5+netcdf+pnetcdf+metis+parmetis+tempest
+moab = moab@5.4.1-RC1+mpi+hdf5+netcdf+pnetcdf+metis+parmetis+tempest
 nco = nco@5.1.2-beta01+openmp
 netcdf_c = netcdf-c@4.8.1+mpi~parallel-netcdf
 netcdf_fortran = netcdf-fortran@4.5.4

--- a/e3sm_supported_machines/default.cfg
+++ b/e3sm_supported_machines/default.cfg
@@ -22,7 +22,7 @@ ilamb = 2.6
 
 # the version of mache to use during deployment (should match the version used
 # in the package itself)
-mache = 1.9.0rc3
+mache = 1.9.0
 
 # the version of mpi4py to build if using system compilers
 mpi4py = 3.1.3
@@ -34,7 +34,7 @@ mpi4py = 3.1.3
 esmf = esmf@8.2.0+mpi+netcdf~pio+pnetcdf
 hdf5 = hdf5@1.12.2+cxx+fortran+hl+mpi+shared
 moab = moab@5.4.1+mpi+hdf5+netcdf+pnetcdf+metis+parmetis+tempest
-nco = nco@5.1.2+openmp
+nco = nco@5.1.3+openmp
 netcdf_c = netcdf-c@4.8.1+mpi~parallel-netcdf
 netcdf_fortran = netcdf-fortran@4.5.4
 tempestextremes = tempestextremes@2.2.1+mpi

--- a/e3sm_supported_machines/default.cfg
+++ b/e3sm_supported_machines/default.cfg
@@ -33,8 +33,8 @@ mpi4py = 3.1.3
 
 esmf = esmf@8.2.0+mpi+netcdf~pio+pnetcdf
 hdf5 = hdf5@1.12.2+cxx+fortran+hl+mpi+shared
-moab = moab@5.4.1-RC1+mpi+hdf5+netcdf+pnetcdf+metis+parmetis+tempest
-nco = nco@5.1.2-beta01+openmp
+moab = moab@5.4.1+mpi+hdf5+netcdf+pnetcdf+metis+parmetis+tempest
+nco = nco@5.1.2+openmp
 netcdf_c = netcdf-c@4.8.1+mpi~parallel-netcdf
 netcdf_fortran = netcdf-fortran@4.5.4
 tempestextremes = tempestextremes@2.2.1+mpi

--- a/e3sm_supported_machines/default.cfg
+++ b/e3sm_supported_machines/default.cfg
@@ -12,7 +12,7 @@ recreate = False
 suffix =
 
 # the python version
-python = 3.9
+python = 3.10
 
 # the MPI version (nompi, mpich or openmpi)
 mpi = nompi
@@ -22,7 +22,7 @@ ilamb = 2.6
 
 # the version of mache to use during deployment (should match the version used
 # in the package itself)
-mache = 1.5.0
+mache = 1.7.0
 
 # the version of mpi4py to build if using system compilers
 mpi4py = 3.1.3
@@ -34,7 +34,7 @@ mpi4py = 3.1.3
 esmf = esmf@8.2.0+mpi+netcdf~pio+pnetcdf
 hdf5 = hdf5@1.12.2+cxx+fortran+hl+mpi+shared
 moab = moab@5.4.0+mpi+hdf5+netcdf+pnetcdf+metis+parmetis+tempest
-nco = nco@5.1.0+openmp
+nco = nco@5.1.1+openmp
 netcdf_c = netcdf-c@4.8.1+mpi~parallel-netcdf
 netcdf_fortran = netcdf-fortran@4.5.4
 tempestextremes = tempestextremes@2.2.1+mpi

--- a/e3sm_supported_machines/deploy_e3sm_unified.py
+++ b/e3sm_supported_machines/deploy_e3sm_unified.py
@@ -79,16 +79,18 @@ def main():
     config = get_config(args.config_file)
 
     conda_base = get_conda_base(args.conda_base, config, shared=False)
+    conda_base = os.path.abspath(conda_base)
 
-    base_activation_script = os.path.abspath(
-        '{}/etc/profile.d/conda.sh'.format(conda_base))
+    source_activation_scripts = \
+        'source {}/etc/profile.d/conda.sh; ' \
+        'source {}/etc/profile.d/mamba.sh'.format(conda_base, conda_base)
 
-    activate_base = 'source {}; conda activate'.format(base_activation_script)
+    activate_base = '{}; conda activate'.format(source_activation_scripts)
 
     activate_install_env = \
-        'source {}; ' \
+        '{}; ' \
         'conda activate temp_e3sm_unified_install'.format(
-            base_activation_script)
+            source_activation_scripts)
 
     # install miniconda if needed
     install_miniconda(conda_base, activate_base)

--- a/e3sm_supported_machines/shared.py
+++ b/e3sm_supported_machines/shared.py
@@ -14,7 +14,7 @@ except ImportError:
 def parse_args(bootstrap):
     parser = argparse.ArgumentParser(
         description='Deploy E3SM-Unified')
-    parser.add_argument("--version", dest="version", default="1.8.0rc6",
+    parser.add_argument("--version", dest="version", default="1.8.0",
                         help="The version of E3SM-Unified to deploy")
     parser.add_argument("--conda", dest="conda_base",
                         help="Path for the  conda base")

--- a/e3sm_supported_machines/shared.py
+++ b/e3sm_supported_machines/shared.py
@@ -14,7 +14,7 @@ except ImportError:
 def parse_args(bootstrap):
     parser = argparse.ArgumentParser(
         description='Deploy E3SM-Unified')
-    parser.add_argument("--version", dest="version", default="1.8.0rc3",
+    parser.add_argument("--version", dest="version", default="1.8.0rc4",
                         help="The version of E3SM-Unified to deploy")
     parser.add_argument("--conda", dest="conda_base",
                         help="Path for the  conda base")

--- a/e3sm_supported_machines/shared.py
+++ b/e3sm_supported_machines/shared.py
@@ -52,7 +52,7 @@ def parse_args(bootstrap):
 
 
 def check_call(commands, env=None):
-    print('running: {}'.format(commands))
+    print('\n\nrunning:\n  {}\n\n'.format('\n  '.join(commands.split('; '))))
     proc = subprocess.Popen(commands, env=env, executable='/bin/bash',
                             shell=True)
     proc.wait()

--- a/e3sm_supported_machines/shared.py
+++ b/e3sm_supported_machines/shared.py
@@ -14,7 +14,7 @@ except ImportError:
 def parse_args(bootstrap):
     parser = argparse.ArgumentParser(
         description='Deploy E3SM-Unified')
-    parser.add_argument("--version", dest="version", default="1.8.0rc2",
+    parser.add_argument("--version", dest="version", default="1.8.0rc3",
                         help="The version of E3SM-Unified to deploy")
     parser.add_argument("--conda", dest="conda_base",
                         help="Path for the  conda base")

--- a/e3sm_supported_machines/shared.py
+++ b/e3sm_supported_machines/shared.py
@@ -89,7 +89,7 @@ def install_miniconda(conda_base, activate_base):
                'conda config --add channels conda-forge; ' \
                'conda config --set channel_priority strict; ' \
                'conda install -y boa; ' \
-               'conda update -y --all; ' \
+               'mamba update -y --all; ' \
                'cp ~/.bashrc ~/.bashrc.conda_bak; ' \
                'mamba init; ' \
                'mv ~/.bashrc.conda_bak ~/.bashrc'.format(activate_base)

--- a/e3sm_supported_machines/shared.py
+++ b/e3sm_supported_machines/shared.py
@@ -14,7 +14,7 @@ except ImportError:
 def parse_args(bootstrap):
     parser = argparse.ArgumentParser(
         description='Deploy E3SM-Unified')
-    parser.add_argument("--version", dest="version", default="1.8.0rc1",
+    parser.add_argument("--version", dest="version", default="1.8.0rc2",
                         help="The version of E3SM-Unified to deploy")
     parser.add_argument("--conda", dest="conda_base",
                         help="Path for the  conda base")

--- a/e3sm_supported_machines/shared.py
+++ b/e3sm_supported_machines/shared.py
@@ -14,7 +14,7 @@ except ImportError:
 def parse_args(bootstrap):
     parser = argparse.ArgumentParser(
         description='Deploy E3SM-Unified')
-    parser.add_argument("--version", dest="version", default="1.7.1",
+    parser.add_argument("--version", dest="version", default="1.8.0rc1",
                         help="The version of E3SM-Unified to deploy")
     parser.add_argument("--conda", dest="conda_base",
                         help="Path for the  conda base")

--- a/e3sm_supported_machines/shared.py
+++ b/e3sm_supported_machines/shared.py
@@ -69,8 +69,9 @@ def install_miniconda(conda_base, activate_base):
             system = 'MacOSX'
         else:
             system = 'Linux'
-        miniconda = 'Miniconda3-latest-{}-x86_64.sh'.format(system)
-        url = 'https://repo.continuum.io/miniconda/{}'.format(miniconda)
+
+        miniconda = 'Mambaforge-{}-x86_64.sh'.format(system)
+        url = 'https://github.com/conda-forge/miniforge/releases/latest/download/{}'.format(miniconda)
         print(url)
         req = Request(url, headers={'User-Agent': 'Mozilla/5.0'})
         f = urlopen(req)
@@ -87,8 +88,11 @@ def install_miniconda(conda_base, activate_base):
     commands = '{}; ' \
                'conda config --add channels conda-forge; ' \
                'conda config --set channel_priority strict; ' \
-               'conda install -y mamba boa; ' \
-               'conda update -y --all'.format(activate_base)
+               'conda install -y boa; ' \
+               'conda update -y --all; ' \
+               'cp ~/.bashrc ~/.bashrc.conda_bak; ' \
+               'mamba init; ' \
+               'mv ~/.bashrc.conda_bak ~/.bashrc'.format(activate_base)
 
     check_call(commands)
 

--- a/e3sm_supported_machines/shared.py
+++ b/e3sm_supported_machines/shared.py
@@ -14,7 +14,7 @@ except ImportError:
 def parse_args(bootstrap):
     parser = argparse.ArgumentParser(
         description='Deploy E3SM-Unified')
-    parser.add_argument("--version", dest="version", default="1.8.0rc4",
+    parser.add_argument("--version", dest="version", default="1.8.0rc5",
                         help="The version of E3SM-Unified to deploy")
     parser.add_argument("--conda", dest="conda_base",
                         help="Path for the  conda base")

--- a/e3sm_supported_machines/shared.py
+++ b/e3sm_supported_machines/shared.py
@@ -14,7 +14,7 @@ except ImportError:
 def parse_args(bootstrap):
     parser = argparse.ArgumentParser(
         description='Deploy E3SM-Unified')
-    parser.add_argument("--version", dest="version", default="1.8.0rc5",
+    parser.add_argument("--version", dest="version", default="1.8.0rc6",
                         help="The version of E3SM-Unified to deploy")
     parser.add_argument("--conda", dest="conda_base",
                         help="Path for the  conda base")

--- a/e3sm_supported_machines/templates/build.template
+++ b/e3sm_supported_machines/templates/build.template
@@ -8,11 +8,11 @@ set -e
 
 
 if [ "{{ build_mpi4py }}" == "True" ]; then
-    MPICC="{{ mpicc }} -shared" python -m pip install --no-binary=mpi4py "mpi4py=={{ mpi4py_version }}"
+    MPICC="{{ mpicc }} -shared" python -m pip install --no-cache-dir "mpi4py=={{ mpi4py_version }}"
 fi
 
 
 
 if [ "{{ build_ilamb }}" == "True" ]; then
-    conda install -y {{ ilamb_channels }} --no-deps "ilamb={{ ilamb_version }}"
+    mamba install -y {{ ilamb_channels }} --no-deps "ilamb={{ ilamb_version }}"
 fi

--- a/e3sm_supported_machines/templates/load_e3sm_unified.csh.template
+++ b/e3sm_supported_machines/templates/load_e3sm_unified.csh.template
@@ -1,5 +1,4 @@
 source {{ conda_base }}/etc/profile.d/conda.csh
-source {{ conda_base }}/etc/profile.d/mamba.csh
 
 setenv E3SMU_SCRIPT "{{ script_filename }}"
 setenv E3SMU_MACHINE "{{ machine }}"
@@ -8,7 +7,7 @@ if ( ! $?SLURM_JOB_ID && ! $?COBALT_JOBID ) then
   # we seem to be on a login node, so load the no-MPI environment
 
   setenv E3SMU_MPI "NOMPI"
-  mamba activate {{ env_nompi }}
+  conda activate {{ env_nompi }}
 
   setenv HDF5_USE_FILE_LOCKING FALSE
 
@@ -16,7 +15,7 @@ else
   # we seem to be on a compute node, so load the MPI environment
 
   setenv E3SMU_MPI "{{ env_type }}"
-  mamba activate {{ env_name }}
+  conda activate {{ env_name }}
 
   {{ spack }}
 

--- a/e3sm_supported_machines/templates/load_e3sm_unified.csh.template
+++ b/e3sm_supported_machines/templates/load_e3sm_unified.csh.template
@@ -1,4 +1,5 @@
 source {{ conda_base }}/etc/profile.d/conda.csh
+source {{ conda_base }}/etc/profile.d/mamba.csh
 
 setenv E3SMU_SCRIPT "{{ script_filename }}"
 setenv E3SMU_MACHINE "{{ machine }}"
@@ -7,7 +8,7 @@ if ( ! $?SLURM_JOB_ID && ! $?COBALT_JOBID ) then
   # we seem to be on a login node, so load the no-MPI environment
 
   setenv E3SMU_MPI "NOMPI"
-  conda activate {{ env_nompi }}
+  mamba activate {{ env_nompi }}
 
   setenv HDF5_USE_FILE_LOCKING FALSE
 
@@ -15,7 +16,7 @@ else
   # we seem to be on a compute node, so load the MPI environment
 
   setenv E3SMU_MPI "{{ env_type }}"
-  conda activate {{ env_name }}
+  mamba activate {{ env_name }}
 
   {{ spack }}
 

--- a/e3sm_supported_machines/templates/load_e3sm_unified.sh.template
+++ b/e3sm_supported_machines/templates/load_e3sm_unified.sh.template
@@ -1,4 +1,5 @@
 source {{ conda_base }}/etc/profile.d/conda.sh
+source {{ conda_base }}/etc/profile.d/mamba.sh
 
 export E3SMU_SCRIPT="{{ script_filename }}"
 export E3SMU_MACHINE="{{ machine }}"
@@ -8,7 +9,7 @@ then
   # we seem to be on a login node, so load the no-MPI environment
 
   export E3SMU_MPI="NOMPI"
-  conda activate {{ env_nompi }}
+  mamba activate {{ env_nompi }}
 
   export HDF5_USE_FILE_LOCKING=FALSE
 
@@ -16,7 +17,7 @@ else
   # we seem to be on a compute node, so load the MPI environment
 
   export E3SMU_MPI="{{ env_type }}"
-  conda activate {{ env_name }}
+  mamba activate {{ env_name }}
 
   {{ spack }}
 

--- a/recipes/e3sm-unified/build_and_upload.bash
+++ b/recipes/e3sm-unified/build_and_upload.bash
@@ -2,7 +2,7 @@
 
 set -e
 
-rm -rf ~/miniconda3/conda-bld
+rm -rf ~/mambaforge/conda-bld
 upload=False
 dev=False
 

--- a/recipes/e3sm-unified/meta.yaml
+++ b/recipes/e3sm-unified/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "E3SM-Unified" %}
-{% set version = "1.8.0rc5" %}
+{% set version = "1.8.0rc6" %}
 {% set build = 0 %}
 
 package:
@@ -31,7 +31,7 @@ requirements:
     ### main packages ###
     - python
     - e3sm_diags 2.8.0rc1
-    - e3sm_to_cmip 1.9.1rc1
+    - e3sm_to_cmip 1.9.1rc2
     - geometric_features 0.7.0
     - globus-cli
     - ilamb 2.6  # [mpi != 'nompi' and mpi != 'hpc']
@@ -39,16 +39,16 @@ requirements:
     - jupyter
     - livvkit 3.0.1
     - mache 1.9.0rc3
-    - moab 5.4.1rc1 {{ mpi_prefix }}_tempest_*  # [mpi != 'hpc']
-    - mpas-analysis 1.8.0rc2
+    - moab 5.4.1 {{ mpi_prefix }}_tempest_*  # [mpi != 'hpc']
+    - mpas-analysis 1.8.0rc3
     - mpas_tools 0.15.0
-    - nco 5.1.2beta01  # [mpi != 'hpc']
+    - nco 5.1.2  # [mpi != 'hpc']
     - pcmdi_metrics 2.3.1
     - tempest-remap 2.1.6  # [mpi != 'hpc']
     - tempest-extremes 2.2.1 {{ mpi_prefix }}_*  # [mpi != 'hpc']
     - xcdat 0.4.0
     - zstash 1.3.0rc2  # [linux]
-    - zppy 2.2.0rc3
+    - zppy 2.2.0rc4
     ### dependencies ###
     - {{ mpi }}  # [mpi != 'nompi' and mpi != 'hpc']
     - blas

--- a/recipes/e3sm-unified/meta.yaml
+++ b/recipes/e3sm-unified/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "E3SM-Unified" %}
-{% set version = "1.8.0rc4" %}
+{% set version = "1.8.0rc5" %}
 {% set build = 0 %}
 
 package:
@@ -38,8 +38,8 @@ requirements:
     - ipython
     - jupyter
     - livvkit 3.0.1
-    - mache 1.9.0rc2
-    - moab 5.4.0 {{ mpi_prefix }}_tempest_*  # [mpi != 'hpc']
+    - mache 1.9.0rc3
+    - moab 5.4.1rc1 {{ mpi_prefix }}_tempest_*  # [mpi != 'hpc']
     - mpas-analysis 1.8.0rc2
     - mpas_tools 0.15.0
     - nco 5.1.2beta01  # [mpi != 'hpc']

--- a/recipes/e3sm-unified/meta.yaml
+++ b/recipes/e3sm-unified/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "E3SM-Unified" %}
-{% set version = "1.8.0rc1" %}
+{% set version = "1.8.0rc2" %}
 {% set build = 0 %}
 
 package:
@@ -38,7 +38,7 @@ requirements:
     - ipython
     - jupyter
     - livvkit 3.0.1
-    - mache 1.7.0
+    - mache 1.8.0rc1
     - moab 5.4.0 {{ mpi_prefix }}_tempest_*  # [mpi != 'hpc']
     - mpas-analysis 1.8.0rc1
     - mpas_tools 0.15.0

--- a/recipes/e3sm-unified/meta.yaml
+++ b/recipes/e3sm-unified/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "E3SM-Unified" %}
-{% set version = "1.8.0rc2" %}
+{% set version = "1.8.0rc3" %}
 {% set build = 0 %}
 
 package:
@@ -38,7 +38,7 @@ requirements:
     - ipython
     - jupyter
     - livvkit 3.0.1
-    - mache 1.8.0rc1
+    - mache 1.8.0rc2
     - moab 5.4.0 {{ mpi_prefix }}_tempest_*  # [mpi != 'hpc']
     - mpas-analysis 1.8.0rc1
     - mpas_tools 0.15.0

--- a/recipes/e3sm-unified/meta.yaml
+++ b/recipes/e3sm-unified/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "E3SM-Unified" %}
-{% set version = "1.7.1" %}
+{% set version = "1.8.0rc1" %}
 {% set build = 0 %}
 
 package:
@@ -31,24 +31,24 @@ requirements:
     ### main packages ###
     - python
     - e3sm_diags 2.7.0
-    - e3sm_to_cmip 1.8.2
-    - geometric_features 0.6.0
+    - e3sm_to_cmip 1.9.1rc1
+    - geometric_features 0.7.0
     - globus-cli
     - ilamb 2.6  # [mpi != 'nompi' and mpi != 'hpc']
     - ipython
     - jupyter
     - livvkit 3.0.1
-    - mache 1.5.0
+    - mache 1.7.0
     - moab 5.4.0 {{ mpi_prefix }}_tempest_*  # [mpi != 'hpc']
-    - mpas-analysis 1.7.2
+    - mpas-analysis 1.8.0rc1
     - mpas_tools 0.15.0
-    - nco 5.1.0  # [mpi != 'hpc']
+    - nco 5.1.1  # [mpi != 'hpc']
     - pcmdi_metrics 2.3.1
     - tempest-remap 2.1.6  # [mpi != 'hpc']
     - tempest-extremes 2.2.1 {{ mpi_prefix }}_*  # [mpi != 'hpc']
-    - xcdat 0.3.0
-    - zstash 1.2.1  # [linux]
-    - zppy 2.1.0
+    - xcdat 0.3.3
+    - zstash 1.3.0rc1  # [linux]
+    - zppy 2.2.0rc2
     ### dependencies ###
     - {{ mpi }}  # [mpi != 'nompi' and mpi != 'hpc']
     - blas
@@ -59,7 +59,7 @@ requirements:
     - cdtime 3.1.4
     - cdutil 8.2.1
     - cmocean
-    - dask 2022.5.2
+    - dask 2022.10.0
     - dogpile.cache
     - eofs
     - esmf 8.2.0 {{ mpi_prefix }}_*  # [mpi != 'hpc']
@@ -96,7 +96,7 @@ requirements:
     - shapely
     - sympy >=0.7.6
     - tabulate
-    - xarray 2022.6.0
+    - xarray 2022.10.0
     - xesmf
 
     # addition ilamb 2.6 dependencies, for system MPI builds

--- a/recipes/e3sm-unified/meta.yaml
+++ b/recipes/e3sm-unified/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "E3SM-Unified" %}
-{% set version = "1.8.0rc3" %}
+{% set version = "1.8.0rc4" %}
 {% set build = 0 %}
 
 package:
@@ -30,7 +30,7 @@ requirements:
   run:
     ### main packages ###
     - python
-    - e3sm_diags 2.7.0
+    - e3sm_diags 2.8.0rc1
     - e3sm_to_cmip 1.9.1rc1
     - geometric_features 0.7.0
     - globus-cli
@@ -38,17 +38,17 @@ requirements:
     - ipython
     - jupyter
     - livvkit 3.0.1
-    - mache 1.8.0rc2
+    - mache 1.9.0rc2
     - moab 5.4.0 {{ mpi_prefix }}_tempest_*  # [mpi != 'hpc']
-    - mpas-analysis 1.8.0rc1
+    - mpas-analysis 1.8.0rc2
     - mpas_tools 0.15.0
-    - nco 5.1.1  # [mpi != 'hpc']
+    - nco 5.1.2beta01  # [mpi != 'hpc']
     - pcmdi_metrics 2.3.1
     - tempest-remap 2.1.6  # [mpi != 'hpc']
     - tempest-extremes 2.2.1 {{ mpi_prefix }}_*  # [mpi != 'hpc']
-    - xcdat 0.3.3
-    - zstash 1.3.0rc1  # [linux]
-    - zppy 2.2.0rc2
+    - xcdat 0.4.0
+    - zstash 1.3.0rc2  # [linux]
+    - zppy 2.2.0rc3
     ### dependencies ###
     - {{ mpi }}  # [mpi != 'nompi' and mpi != 'hpc']
     - blas

--- a/recipes/e3sm-unified/meta.yaml
+++ b/recipes/e3sm-unified/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "E3SM-Unified" %}
-{% set version = "1.8.0rc6" %}
+{% set version = "1.8.0" %}
 {% set build = 0 %}
 
 package:
@@ -30,25 +30,25 @@ requirements:
   run:
     ### main packages ###
     - python
-    - e3sm_diags 2.8.0rc1
-    - e3sm_to_cmip 1.9.1rc2
+    - e3sm_diags 2.8.0
+    - e3sm_to_cmip 1.9.1
     - geometric_features 0.7.0
     - globus-cli
     - ilamb 2.6  # [mpi != 'nompi' and mpi != 'hpc']
     - ipython
     - jupyter
     - livvkit 3.0.1
-    - mache 1.9.0rc3
+    - mache 1.9.0
     - moab 5.4.1 {{ mpi_prefix }}_tempest_*  # [mpi != 'hpc']
-    - mpas-analysis 1.8.0rc3
+    - mpas-analysis 1.8.0
     - mpas_tools 0.15.0
-    - nco 5.1.2  # [mpi != 'hpc']
+    - nco 5.1.3  # [mpi != 'hpc']
     - pcmdi_metrics 2.3.1
     - tempest-remap 2.1.6  # [mpi != 'hpc']
     - tempest-extremes 2.2.1 {{ mpi_prefix }}_*  # [mpi != 'hpc']
     - xcdat 0.4.0
-    - zstash 1.3.0rc2  # [linux]
-    - zppy 2.2.0rc4
+    - zstash 1.3.0  # [linux]
+    - zppy 2.2.0
     ### dependencies ###
     - {{ mpi }}  # [mpi != 'nompi' and mpi != 'hpc']
     - blas


### PR DESCRIPTION
## In this version

* 5 packages built with Spack for use on compute nodes:
  * esmf 8.2.0
  * moab 5.4.1
  * nco 5.1.3
  * tempestextremes 2.2.1
  * tempestremap 2.1.6
* Many packages have been updated.  In addition to `moab` and `nco` listed above, notable updates include:
  * e3sm_diags 2.8.0
  * e3sm_to_cmip 1.9.1
  * geometric_features 0.7.0
  * mache 1.9.0
  * mpas-analysis 1.8.0
  * mpas_tools 0.15.0
  * xcdat 0.4.0
  * zppy 2.2.0
  * zstash 1.3.0

## New and improved

* **E3SM Diags**: Adds MERRA2 aerosol data for AOD diagnostics, Aerosol Budget Tables (set name: "aerosol_budget", and an example for running with zppy. Other changes include fixing a matplotlib rotation bug and removing `cdtime` as a dependency.  More updates can be found in the [v2.8.0 Release Notes](https://github.com/E3SM-Project/e3sm_diags/releases/tag/v2.8.0).
* **e3sm_to_cmip**: v1.9.0 and v1.9.1 were released since the previous E3SM-unified version. New features include support for E3SM v2 MPAS variables and `nco>=5.11`. They also include various bug fixes for accessing the underlying variable data using xarray and/or numpy. More updates can be found in the [v1.9.0](https://github.com/E3SM-Project/e3sm_to_cmip/releases/tag/v1.9.0) and [v1.9.1](https://github.com/E3SM-Project/e3sm_to_cmip/releases/tag/v1.9.1) release notes.
* **MPAS-Analysis**:  New features have been added from the recent [E3SM hackathon on MPAS-Analysis](https://e3sm.org/hackathon-2-retrospective/): Arctic regional analysis, barotropic streamfunctions, sea-ice production and melting and sea-surface height histograms.  More updates can be found in the [v1.8.0 Release Notes](https://github.com/MPAS-Dev/MPAS-Analysis/releases/tag/1.8.0).

* **MOAB**: Preliminary support for bilinear maps (serial only), several bug fixes, and memory usage/performance improvements for offline map generation. For more information, refer to the [detailed release notes for v5.4.0 and v5.4.1](https://bitbucket.org/fathomteam/moab/src/master/RELEASE_NOTES.md).

* **NCO**: Compression support improved, `ncremap` supports EAMxx and new vertical interpolation methods, NCZarr support added, see the [release notes for versions 5.1.1-5.1.3](https://github.com/nco/nco/releases) 

* **xcdat**: There have been several releases since the previous E3SM-unified including v0.3.1, v0.3.2, v0.3.3, and most recently v0.4.0. All of these releases address various bug fixes for features such as spatial/temporal averaging and horizontal regridding. v0.4.0 introduces includes a feature update to support datasets that have N dimensions mapped to N coordinates to represent an axis.updates (e.g., E3SM native datasets). See the [changelog](https://xcdat.readthedocs.io/en/latest/history.html) for a complete list of updates.

* **zppy**: `zppy 2.2.0` adds Perlmutter support and hemispheric averaging in time series. More updates can be found in the [v2.2.0 Release Notes](https://github.com/E3SM-Project/zppy/releases/tag/v2.2.0).

* **zstash**: `zstash 1.3.0` adds an option to retry hsi get if it is unsuccessful. It also optimizes Globus transfers. More updates can be found in the [v1.3.0 Release Notes](https://github.com/E3SM-Project/zstash/releases/tag/v1.3.0).

## Deployment
Deployed on:
- [x] Acme1
- [x] Andes
- [x] Anvil
- [x] Chrysalis
- [x] Compy
- [x] Cori-Haswell
- [x] Perlmutter-CPU
