### PR TITLE
Update to v1.9.1

### DIFF
--- a/e3sm_supported_machines/bootstrap.py
+++ b/e3sm_supported_machines/bootstrap.py
@@ -134,8 +134,7 @@ def build_env(is_test, recreate, compiler, mpi, conda_mpi, version,
                 channels = f'{channels} -c conda-forge/label/{package}_dev'
 
         # edit if not using a release candidate for a given package
-        dev_labels = ['e3sm_to_cmip', 'e3sm_diags',
-                      'mache', 'mpas_analysis', 'zppy', 'zstash']
+        dev_labels = ['zppy', 'zstash']
         for package in dev_labels:
             channels = f'{channels} -c conda-forge/label/{package}_dev'
         channels = f'{channels} ' \

--- a/e3sm_supported_machines/default.cfg
+++ b/e3sm_supported_machines/default.cfg
@@ -37,8 +37,8 @@ esmpy = 8.4.2
 
 esmf = esmf@8.4.2+mpi+netcdf~pnetcdf~external-parallelio
 hdf5 = hdf5@1.14.1+cxx+fortran+hl+mpi+shared
-moab = moab@5.5.0+mpi+hdf5+netcdf+pnetcdf+metis+parmetis+tempest
-nco = nco@5.1.7+openmp
+moab = moab@5.5.1+mpi+hdf5+netcdf+pnetcdf+metis+parmetis+tempest
+nco = nco@5.1.9+openmp
 netcdf_c = netcdf-c@4.9.2+mpi~parallel-netcdf
 netcdf_fortran = netcdf-fortran@4.5.4
 parallel_netcdf = parallel-netcdf@1.12.3

--- a/e3sm_supported_machines/shared.py
+++ b/e3sm_supported_machines/shared.py
@@ -14,7 +14,7 @@ except ImportError:
 def parse_args(bootstrap):
     parser = argparse.ArgumentParser(
         description='Deploy E3SM-Unified')
-    parser.add_argument("--version", dest="version", default="1.9.1rc1",
+    parser.add_argument("--version", dest="version", default="1.9.1rc2",
                         help="The version of E3SM-Unified to deploy")
     parser.add_argument("--conda", dest="conda_base",
                         help="Path for the  conda base")

--- a/e3sm_supported_machines/shared.py
+++ b/e3sm_supported_machines/shared.py
@@ -14,7 +14,7 @@ except ImportError:
 def parse_args(bootstrap):
     parser = argparse.ArgumentParser(
         description='Deploy E3SM-Unified')
-    parser.add_argument("--version", dest="version", default="1.9.1rc2",
+    parser.add_argument("--version", dest="version", default="1.9.1",
                         help="The version of E3SM-Unified to deploy")
     parser.add_argument("--conda", dest="conda_base",
                         help="Path for the  conda base")

--- a/e3sm_supported_machines/shared.py
+++ b/e3sm_supported_machines/shared.py
@@ -14,7 +14,7 @@ except ImportError:
 def parse_args(bootstrap):
     parser = argparse.ArgumentParser(
         description='Deploy E3SM-Unified')
-    parser.add_argument("--version", dest="version", default="1.9.0",
+    parser.add_argument("--version", dest="version", default="1.9.1rc1",
                         help="The version of E3SM-Unified to deploy")
     parser.add_argument("--conda", dest="conda_base",
                         help="Path for the  conda base")

--- a/recipes/e3sm-unified/build_and_upload.bash
+++ b/recipes/e3sm-unified/build_and_upload.bash
@@ -4,7 +4,7 @@ set -e
 
 rm -rf ~/mambaforge/conda-bld
 upload=False
-dev=True
+dev=False
 
 if [ $dev == "True" ]
 then
@@ -15,8 +15,8 @@ else
   channels="-c conda-forge"
 fi
 
-for file in configs/mpi_mpich_python3.10.yaml configs/mpi_hpc_python3.10.yaml
-# for file in configs/mpi_*_python*.yaml
+# for file in configs/mpi_mpich_python3.10.yaml configs/mpi_hpc_python3.10.yaml
+for file in configs/mpi_*_python*.yaml
 do
   conda mambabuild -m $file --override-channels --use-local $channels .
 done

--- a/recipes/e3sm-unified/build_and_upload.bash
+++ b/recipes/e3sm-unified/build_and_upload.bash
@@ -4,23 +4,19 @@ set -e
 
 rm -rf ~/mambaforge/conda-bld
 upload=False
-dev=False
+dev=True
 
 if [ $dev == "True" ]
 then
-  channels="-c conda-forge/label/e3sm_diags_dev \
-            -c conda-forge/label/e3sm_to_cmip_dev \
-            -c conda-forge/label/mache_dev \
-            -c conda-forge/label/mpas_analysis_dev \
+  channels="-c conda-forge/label/zstash_dev \
             -c conda-forge/label/zppy_dev \
-            -c conda-forge \
-            -c defaults"
+            -c conda-forge"
 else
-  channels="-c conda-forge -c defaults"
+  channels="-c conda-forge"
 fi
 
-#for file in configs/mpi_hpc_python3.10.yaml configs/mpi_mpich_python3.10.yaml
-for file in configs/mpi_*_python*.yaml
+for file in configs/mpi_mpich_python3.10.yaml configs/mpi_hpc_python3.10.yaml
+# for file in configs/mpi_*_python*.yaml
 do
   conda mambabuild -m $file --override-channels --use-local $channels .
 done

--- a/recipes/e3sm-unified/meta.yaml
+++ b/recipes/e3sm-unified/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "E3SM-Unified" %}
-{% set version = "1.9.1rc2" %}
+{% set version = "1.9.1" %}
 {% set build = 0 %}
 
 package:
@@ -49,8 +49,8 @@ requirements:
     - tempest-remap 2.2.0  # [mpi != 'hpc']
     - tempest-extremes 2.2.1 {{ mpi_prefix }}_*  # [mpi != 'hpc']
     - xcdat 0.5.0
-    - zppy 2.3.1rc1
-    - zstash 1.4.1rc1  # [linux]
+    - zppy 2.3.1
+    - zstash 1.4.1  # [linux]
     ### dependencies ###
     - {{ mpi }}  # [mpi != 'nompi' and mpi != 'hpc']
     - blas

--- a/recipes/e3sm-unified/meta.yaml
+++ b/recipes/e3sm-unified/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "E3SM-Unified" %}
-{% set version = "1.9.0" %}
+{% set version = "1.9.1rc1" %}
 {% set build = 0 %}
 
 package:
@@ -41,16 +41,16 @@ requirements:
     - jupyter
     - livvkit 3.0.1
     - mache 1.17.0
-    - moab 5.5.0 {{ mpi_prefix }}_tempest_*  # [mpi != 'hpc']
+    - moab 5.5.1 {{ mpi_prefix }}_tempest_*  # [mpi != 'hpc']
     - mpas-analysis 1.9.0
-    - mpas_tools 0.23.0
-    - nco 5.1.7  # [mpi != 'hpc']
+    - mpas_tools 0.27.0
+    - nco 5.1.9  # [mpi != 'hpc']
     - pcmdi_metrics 2.3.1
     - tempest-remap 2.2.0  # [mpi != 'hpc']
     - tempest-extremes 2.2.1 {{ mpi_prefix }}_*  # [mpi != 'hpc']
     - xcdat 0.5.0
-    - zppy 2.3.0
-    - zstash 1.4.0  # [linux]
+    - zppy 2.3.1rc1
+    - zstash 1.4.1rc1  # [linux]
     ### dependencies ###
     - {{ mpi }}  # [mpi != 'nompi' and mpi != 'hpc']
     - blas
@@ -71,7 +71,7 @@ requirements:
     - genutil 8.2.1
     - globus-sdk
     - gsw
-    - hdf5 1.14.1 {{ mpi_prefix }}_*
+    - hdf5 1.14.2 {{ mpi_prefix }}_*
     - ipygany
     - libnetcdf 4.9.2 {{ mpi_prefix }}_*
     - lxml

--- a/recipes/e3sm-unified/meta.yaml
+++ b/recipes/e3sm-unified/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "E3SM-Unified" %}
-{% set version = "1.9.1rc1" %}
+{% set version = "1.9.1rc2" %}
 {% set build = 0 %}
 
 package:
@@ -75,7 +75,7 @@ requirements:
     - ipygany
     - libnetcdf 4.9.2 {{ mpi_prefix }}_*
     - lxml
-    - matplotlib
+    - matplotlib 3.7.1
     - metpy
     - mpi4py  # [mpi != 'nompi' and mpi != 'hpc']
     - nb_conda


### PR DESCRIPTION
## In this version

* 5 packages built with Spack for use on compute nodes:
  * esmf 8.4.2
  * moab 5.5.1
  * nco 5.1.9
  * tempestextremes 2.2.1
  * tempestremap 2.2.0
* A few packages have been updated.  In addition to `moab` and `nco` listed above, notable updates include:
  * mpas_tools 0.27.0
  * zppy 2.3.1
  * zstash 1.4.1

## New and improved

* **MOAB**: 
  * New ESMF format NC reader support
  * Improved support for reading MPAS files directly
  * Improved [API documentation](https://web.cels.anl.gov/projects/sigma/docs/moab/index.html.) now available 
  * Fix several outstanding issues in `mbtempest` tool
    * Propagate `grid_dims` correctly for RLL grids
    * Store `history` metadata as attributes for provenance
  * A new halo-exchange example to measure performance of nearest-neighbor halo-exchange communication kernels
  * Several configuration and build updates for running on ALCF and OLCF systems

* **NCO**: 
  * See full release notes at https://github.com/nco/nco/blob/5.1.9/doc/ANNOUNCE 
  * ncremap now, by default, fills with 0.0 (instead of FillValue) gridcells where sub-gridscale fraction is zero. Previous behavior (filling with FillValue) can be restored with new `--mpt_mss` option.
  * ncremap supports new TR bilinear and integrated bilinear algorithm types
  * ncremap supports new standard names <WeightGenerator><AlgType> for old algorithms, e.g., `esmfaave`, `traave`, `ncoaave` 
  * ncra, ncrcat fix behavior of dimension interleave (ILV) parameter [NCO 5.1.9 User Guide](http://nco.sf.net/nco.html#bug_ilv)
  * All operator fix possible path separator issue in MS Windows
  * Improved inferral of MALI grids (radians rather than degrees automatically detected)
  * Support for attributes stored as NC_STRING rather than NC_CHAR

* **zppy**: A new parameter `keep_mvm_case_name_in_fig` enables turning on and off `ref_name` in e3sm_diags figure names in model vs model case. The current IICE comparison viewer will work seamlessly again with e3sm_diags output generated with `keep_mvm_case_name_in_fig=False` for model vs model runs. Additionally, the default set order for E3SM Diags has been returned to its original order, and the machine name can now be discovered on compute nodes while using E3SM Unified.

* **zstash**:  Globus endpoints are beginning to require extra consents. This latest version of `zstash`  addresses this issue by automatically prompting the user for authentication credentials to provide these consents, if required..

## Deployment
Deployed on:
- [ ] Acme1
- [x] Andes
- [x] Anvil
- [x] Chicoma
- [x] Chrysalis
- [x] Compy
- [x] Frontier
- [x] Perlmutter-CPU

## Sync Diagnostics
Synced on:
- [ ] Acme1
- [x] Andes
- [x] Anvil
- [ ] Chicoma - not enough space
- [x] Chrysalis
- [x] Compy
- [x] Frontier
- [x] Perlmutter-CPU