### PR TITLE
Bump evv version for cime-env

### DIFF
--- a/e3sm_supported_machines/create_new_cime_env.bash
+++ b/e3sm_supported_machines/create_new_cime_env.bash
@@ -21,10 +21,10 @@ check_env () {
 
 # Modify the following to choose which cime-env version(s)
 # the python version(s) are installed
-versions=(1.7.0)
-pythons=(3.9)
+versions=(1.8.0)
+pythons=(3.12)
 
-default_python=3.9
+default_python=3.12
 
 # Any subsequent commands which fail will cause the shell script to exit
 # immediately

--- a/recipes/cime-env/meta.yaml
+++ b/recipes/cime-env/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "CIME-env" %}
-{% set version = "1.7.0" %}
+{% set version = "1.8.0" %}
 
 package:
   name: {{ name|lower }}
@@ -11,12 +11,12 @@ build:
 
 requirements:
   host:
-    - python >=3.7
+    - python >=3.9
   run:
     ### main packages ###
-    - python >=3.7
+    - python >=3.9
     # channel: conda-forge
-    - evv4esm 0.5.0
+    - evv4esm 0.5.1
     ### dependencies ###
     # channel: conda-forge
     - numpy >1.13


### PR DESCRIPTION
EVV v0.5.1 fixes an issue when TSC test is has a non-b4b result (regardless of passing/failing) using pandas version >2.0