### PR TITLE
Update evv4esm version

### DIFF
--- a/recipes/cime-env/meta.yaml
+++ b/recipes/cime-env/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "CIME-env" %}
-{% set version = "1.9.0" %}
+{% set version = "1.10.0" %}
 
 package:
   name: {{ name|lower }}
@@ -16,7 +16,7 @@ requirements:
     ### main packages ###
     - python >=3.9
     # channel: conda-forge
-    - evv4esm 0.5.2
+    - evv4esm 0.6.2
     ### dependencies ###
     # channel: conda-forge
     - numpy >1.13


### PR DESCRIPTION
Update evv4esm version to support latest analysis featured in evv4esm v0.6.2, will be needed for https://github.com/E3SM-Project/E3SM/pull/8266