### PR TITLE
Update to 1.13.0

### DIFF
--- a/.github/workflows/build_workflow.yml
+++ b/.github/workflows/build_workflow.yml
@@ -30,37 +30,37 @@ jobs:
           - python-version: "3.11"
             pixi-environment: py311
             mpi: nompi
-          - python-version: "3.11"
-            pixi-environment: py311
-            mpi: mpich
-          - python-version: "3.11"
-            pixi-environment: py311
-            mpi: openmpi
+          # - python-version: "3.11"
+          #   pixi-environment: py311
+          #   mpi: mpich
+          # - python-version: "3.11"
+          #   pixi-environment: py311
+          #   mpi: openmpi
           - python-version: "3.12"
             pixi-environment: py312
             mpi: hpc
           - python-version: "3.12"
             pixi-environment: py312
             mpi: nompi
-          - python-version: "3.12"
-            pixi-environment: py312
-            mpi: mpich
-          - python-version: "3.12"
-            pixi-environment: py312
-            mpi: openmpi
+          # - python-version: "3.12"
+          #   pixi-environment: py312
+          #   mpi: mpich
+          # - python-version: "3.12"
+          #   pixi-environment: py312
+          #   mpi: openmpi
           - python-version: "3.13"
             pixi-environment: py313
             mpi: hpc
           - python-version: "3.13"
             pixi-environment: py313
             mpi: nompi
-          - python-version: "3.13"
-            pixi-environment: py313
-            mpi: mpich
-          - python-version: "3.13"
-            pixi-environment: py313
-            mpi: openmpi
-      fail-fast: false
+      #     - python-version: "3.13"
+      #       pixi-environment: py313
+      #       mpi: mpich
+      #     - python-version: "3.13"
+      #       pixi-environment: py313
+      #       mpi: openmpi
+      # fail-fast: false
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/docs_workflow.yml
+++ b/.github/workflows/docs_workflow.yml
@@ -8,7 +8,7 @@ on:
     types: [published]
 
 env:
-  PIXI_ENVIRONMENT: "py310"
+  PIXI_ENVIRONMENT: "py311"
 
 jobs:
   publish-docs:

--- a/.pixi/config.toml
+++ b/.pixi/config.toml
@@ -1,6 +1,0 @@
-# Keep conda-forge label channels on Anaconda because prefix.dev does not
-# currently mirror public conda-forge labels such as mache_dev.
-[mirrors]
-"https://conda.anaconda.org/conda-forge/label" = [
-  "https://conda.anaconda.org/conda-forge/label",
-]

--- a/deploy/cli_spec.json
+++ b/deploy/cli_spec.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "software": "e3sm-unified",
-    "mache_version": "3.5.0",
+    "mache_version": "3.6.0",
     "description": "Deploy e3sm-unified environment"
   },
   "arguments": [

--- a/deploy/cli_spec.json
+++ b/deploy/cli_spec.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "software": "e3sm-unified",
-    "mache_version": "3.6.0",
+    "mache_version": "3.6.1",
     "description": "Deploy e3sm-unified environment"
   },
   "arguments": [

--- a/deploy/hooks.py
+++ b/deploy/hooks.py
@@ -335,7 +335,9 @@ def pre_publish(ctx: DeployContext) -> dict[str, Any] | None:
         _get_optional_runtime_pixi_value(ctx, 'login_prefix')
     )
     if login_prefix is None:
-        return None
+        login_prefix = _normalize_optional_path(
+            _get_runtime_pixi_value(ctx, 'prefix')
+        )
 
     machine_tag = ctx.machine or 'local'
     nco_root = prefix_root / 'e3smu_latest_for_nco'

--- a/deploy/hooks.py
+++ b/deploy/hooks.py
@@ -279,7 +279,6 @@ def post_spack(ctx: DeployContext) -> None:
             f'"ilamb=={ilamb_version}"'
         )
 
-    view_path = Path(str(spack_result['view_path']))
     if esmpy_version is not None:
         esmf_dir = SOURCE_BUILD_DIR / f'esmf-{esmpy_version}'
         esmpy_dir = esmf_dir / 'src' / 'addon' / 'esmpy'
@@ -289,8 +288,7 @@ def post_spack(ctx: DeployContext) -> None:
             [
                 f'git clone https://github.com/esmf-org/esmf.git '
                 f'-b v{esmpy_version} {shlex.quote(str(esmf_dir))}',
-                'export ESMFMKFILE='
-                f'{shlex.quote(str(view_path / "lib/esmf.mk"))}',
+                'export ESMFMKFILE="${CONDA_PREFIX}/lib/esmf.mk"',
                 (
                     'cd '
                     f'{shlex.quote(str(esmpy_dir))} '
@@ -308,8 +306,7 @@ def post_spack(ctx: DeployContext) -> None:
             [
                 f'git clone https://github.com/pangeo-data/xESMF.git '
                 f'-b v{xesmf_version} {shlex.quote(str(xesmf_dir))}',
-                'export ESMFMKFILE='
-                f'{shlex.quote(str(view_path / "lib/esmf.mk"))}',
+                'export ESMFMKFILE="${CONDA_PREFIX}/lib/esmf.mk"',
                 (
                     f'cd {shlex.quote(str(xesmf_dir))} '
                     '&& python -m pip install --no-deps --no-build-isolation .'

--- a/deploy/hooks.py
+++ b/deploy/hooks.py
@@ -332,7 +332,7 @@ def pre_publish(ctx: DeployContext) -> dict[str, Any] | None:
         return None
 
     login_prefix = _normalize_optional_path(
-        _get_runtime_pixi_value(ctx, 'login_prefix')
+        _get_optional_runtime_pixi_value(ctx, 'login_prefix')
     )
     if login_prefix is None:
         return None
@@ -849,6 +849,18 @@ def _get_runtime_pixi_value(ctx: DeployContext, key: str) -> str:
     value = runtime_pixi.get(key)
     if value is None:
         raise ValueError(f'runtime.pixi.{key} is missing')
+    return str(value)
+
+
+def _get_optional_runtime_pixi_value(
+    ctx: DeployContext, key: str
+) -> str | None:
+    runtime_pixi = ctx.runtime.get('pixi', {})
+    if not isinstance(runtime_pixi, dict):
+        raise ValueError('runtime.pixi is missing or invalid')
+    value = runtime_pixi.get(key)
+    if value is None:
+        return None
     return str(value)
 
 

--- a/deploy/load.sh
+++ b/deploy/load.sh
@@ -27,7 +27,8 @@ if command -v pnetcdf-config >/dev/null 2>&1; then
     export PNETCDF="$(dirname "$(dirname "$(command -v pnetcdf-config)")")"
 fi
 
-if [ -n "${MACHE_DEPLOY_SPACK_LIBRARY_VIEW:-}" ]; then
+if [[ "${MACHE_DEPLOY_ACTIVE_ENV_KIND}" == "compute" ]] && \
+        [ -n "${MACHE_DEPLOY_SPACK_LIBRARY_VIEW:-}" ]; then
     export PIO="${MACHE_DEPLOY_SPACK_LIBRARY_VIEW}"
     export METIS_ROOT="${MACHE_DEPLOY_SPACK_LIBRARY_VIEW}"
     export PARMETIS_ROOT="${MACHE_DEPLOY_SPACK_LIBRARY_VIEW}"

--- a/deploy/load.sh
+++ b/deploy/load.sh
@@ -32,9 +32,7 @@ if [[ "${MACHE_DEPLOY_ACTIVE_ENV_KIND}" == "compute" ]] && \
     export PIO="${MACHE_DEPLOY_SPACK_LIBRARY_VIEW}"
     export METIS_ROOT="${MACHE_DEPLOY_SPACK_LIBRARY_VIEW}"
     export PARMETIS_ROOT="${MACHE_DEPLOY_SPACK_LIBRARY_VIEW}"
-    if [ -f "${MACHE_DEPLOY_SPACK_LIBRARY_VIEW}/lib/esmf.mk" ]; then
-        export ESMFMKFILE="${MACHE_DEPLOY_SPACK_LIBRARY_VIEW}/lib/esmf.mk"
-    fi
-elif [ -n "${CONDA_PREFIX:-}" ] && [ -f "${CONDA_PREFIX}/lib/esmf.mk" ]; then
-    export ESMFMKFILE="${CONDA_PREFIX}/lib/esmf.mk"
 fi
+# We want the pixi version of ESMF on both login and compute nodes.
+# This is for e3sm_diags.
+export ESMFMKFILE="${CONDA_PREFIX}/lib/esmf.mk"

--- a/deploy/pins.cfg
+++ b/deploy/pins.cfg
@@ -6,19 +6,19 @@ mache = 3.5.0
 
 # pins for the spack environment
 [spack]
-esmf = 8.9.0
+esmf = 8.9.1
 hdf5 = 1.14.6
 moab = 5.6.0
-nco = 5.3.6
-netcdf_c = 4.9.3
-netcdf_fortran = 4.5.4
-parallel_netcdf = 1.12.3
-tempest_extremes = 2.4
+nco = 5.3.7
+netcdf_c = 4.10.0
+netcdf_fortran = 4.6.2
+parallel_netcdf = 1.14.1
+tempest_extremes = 2.4.2
 tempest_remap = 2.2.0
 
 # pins for hpc post-install steps
 [hpc]
-ilamb = 2.7.2
+ilamb = 2.7.3
 mpi4py = 4.1.1
 esmpy = None
 xesmf = None

--- a/deploy/pins.cfg
+++ b/deploy/pins.cfg
@@ -2,14 +2,14 @@
 [pixi]
 bootstrap_python = 3.13
 python = 3.13
-mache = 3.5.0
+mache = 3.6.0
 
 # pins for the spack environment
 [spack]
 esmf = 8.9.1
 hdf5 = 1.14.6
 moab = 5.6.0
-nco = 5.3.7
+nco = 5.3.9
 netcdf_c = 4.10.0
 netcdf_fortran = 4.6.2
 parallel_netcdf = 1.14.1

--- a/deploy/pins.cfg
+++ b/deploy/pins.cfg
@@ -2,7 +2,7 @@
 [pixi]
 bootstrap_python = 3.13
 python = 3.13
-mache = 3.6.0
+mache = 3.6.1
 
 # pins for the spack environment
 [spack]

--- a/deploy/pins.cfg
+++ b/deploy/pins.cfg
@@ -18,7 +18,7 @@ tempest_remap = 2.2.0
 
 # pins for hpc post-install steps
 [hpc]
-ilamb = 2.7.3
+ilamb = 2.7.2
 mpi4py = 4.1.1
 esmpy = None
 xesmf = None

--- a/pixi.toml
+++ b/pixi.toml
@@ -5,7 +5,7 @@ platforms = ["linux-64"]
 channel-priority = "strict"
 
 [dependencies]
-python = ">=3.10,<3.14"
+python = ">=3.11,<3.14"
 mache = "==3.3.0"
 pytest = "*"
 pyyaml = "*"
@@ -13,9 +13,6 @@ rattler-build = "*"
 sphinx = ">=7.0.0"
 sphinx_rtd_theme = "*"
 "myst-parser" = "*"
-
-[feature.py310.dependencies]
-python = "3.10.*"
 
 [feature.py311.dependencies]
 python = "3.11.*"
@@ -27,7 +24,6 @@ python = "3.12.*"
 python = "3.13.*"
 
 [environments]
-py310 = ["py310"]
 py311 = ["py311"]
 py312 = ["py312"]
 py313 = ["py313"]

--- a/pixi.toml
+++ b/pixi.toml
@@ -6,7 +6,7 @@ channel-priority = "strict"
 
 [dependencies]
 python = ">=3.10,<3.14"
-mache = "==3.3.0rc1"
+mache = "==3.3.0"
 pytest = "*"
 pyyaml = "*"
 rattler-build = "*"

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -122,7 +122,9 @@ def test_pre_pixi_defaults_to_nompi_single_for_pixi_only_machine(tmp_path: Path)
     assert updates['toolchain'] == {}
 
 
-def test_pre_publish_skips_nco_alias_without_login_prefix(tmp_path: Path):
+def test_pre_publish_falls_back_to_pixi_prefix_without_login_prefix(
+    tmp_path: Path,
+):
     base_path = tmp_path / 'e3sm-unified'
     machine_cfg_path = _write_machine_cfg(
         tmp_path,
@@ -140,8 +142,15 @@ def test_pre_publish_skips_nco_alias_without_login_prefix(tmp_path: Path):
 
     updates = deploy_hooks.pre_publish(ctx)
 
-    assert updates is None
-    assert not (base_path / 'e3smu_latest_for_nco').exists()
+    nco_root = base_path / 'e3smu_latest_for_nco'
+    machine_link = nco_root / 'polaris'
+    assert updates == {
+        'shared': {
+            'managed_directories': [str(nco_root)],
+        }
+    }
+    assert machine_link.is_symlink()
+    assert machine_link.readlink() == Path(ctx.runtime['pixi']['prefix'])
 
 
 def test_pre_publish_adds_nco_alias_for_dual_env_release(tmp_path: Path):

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -122,6 +122,58 @@ def test_pre_pixi_defaults_to_nompi_single_for_pixi_only_machine(tmp_path: Path)
     assert updates['toolchain'] == {}
 
 
+def test_pre_publish_skips_nco_alias_without_login_prefix(tmp_path: Path):
+    base_path = tmp_path / 'e3sm-unified'
+    machine_cfg_path = _write_machine_cfg(
+        tmp_path,
+        group='E3SMinput',
+        base_path=str(base_path),
+    )
+    ctx = _ctx(
+        tmp_path=tmp_path,
+        machine='polaris',
+        machine_cfg_path=machine_cfg_path,
+    )
+    ctx.args.release = True
+    ctx.runtime.update(deploy_hooks.pre_pixi(ctx) or {})
+    ctx.runtime['pixi'].pop('login_prefix')
+
+    updates = deploy_hooks.pre_publish(ctx)
+
+    assert updates is None
+    assert not (base_path / 'e3smu_latest_for_nco').exists()
+
+
+def test_pre_publish_adds_nco_alias_for_dual_env_release(tmp_path: Path):
+    base_path = tmp_path / 'e3sm-unified'
+    machine_cfg_path = _write_machine_cfg(
+        tmp_path,
+        group='users',
+        base_path=str(base_path),
+        compiler='gnu',
+        mpi='openmpi',
+    )
+    ctx = _ctx(
+        tmp_path=tmp_path,
+        machine='compy',
+        machine_cfg_path=machine_cfg_path,
+    )
+    ctx.args.release = True
+    ctx.runtime.update(deploy_hooks.pre_pixi(ctx) or {})
+
+    updates = deploy_hooks.pre_publish(ctx)
+
+    nco_root = base_path / 'e3smu_latest_for_nco'
+    machine_link = nco_root / 'compy'
+    assert updates == {
+        'shared': {
+            'managed_directories': [str(nco_root)],
+        }
+    }
+    assert machine_link.is_symlink()
+    assert machine_link.readlink() == Path(ctx.runtime['pixi']['login_prefix'])
+
+
 def test_ensure_feedstock_submodule_initializes_missing_recipe(
     tmp_path: Path, monkeypatch
 ):


### PR DESCRIPTION
## In this version
* Many packages have been updated, including:
    - cprnc 1.1.4
    - e3sm_diags 3.2.0
    - e3sm_to_cmip 1.14.0
    - geometric_features 1.6.3
    - livvext 1.1.2
    - livvkit 3.3.1
    - mache 3.6.1
    - mosaic 1.3.0
    - mpas-analysis 1.15.0
    - mpas_tools 1.5.1
    - nco 5.3.9
    - pcmdi_metrics 4.0.4
    - tempest-extremes 2.4.2
    - xcdat 0.11.2
    - zppy 3.2.0
    - zppy-interfaces 0.2.1
    - zstash 1.6.0
    - dask 2026.3.0
    - libnetcdf 4.10.0
    - matplotlib 3.10.8
    - ncview 2.1.11
    - netcdf4 1.7.4 
    - proj 9.7.1
    - pytorch 2.10.0
    - r-dplyr 1.2.0
    - xarray 2026.2.0
    - xesmf 0.9.2
    
* python versions `3.11`, `3.12`, and `3.13` will be supported

* we have to drop support for conda-forge `mpich` and `openmpi`, as E3SM-Diags can't support them.

## Important Updates in 1.13.0

**E3SM-Diags** 3.2.0:

* Added new diagnostics, including Precipitation PDF over specified regions and AIRS Spectral OLR.  
* Improved EAMxx and simulator support, including updates for new v3 simulator output and workflow changes.  
* Improved S2D timeseries handling with support for arbitrary start months.

**e3sm\_to\_cmip** 1.14.0:

* Added EAMxx support for CMORization.  
* Updated variable support for v3 ELM.  
* Added an \--on-var-failure flag to control how variable-processing failures are handled.

**LIVVKit** 3.3.1 and **LIVVExt** 1.1.0:

* Generates AIS+GIS surface mass balance and surface energy balance diagnostics  
* Timeseries and climate-mean plots available  
* Comparisons of ELM snowpack, fluxes, and state to RACMO 2.4, ERA5, CERES, MERRA2

**mosaic** 1.3.0:

* Revamped how we handle projecting spherical meshes, so that we now support **all** cartopty [projections](https://cartopy.readthedocs.io/stable/reference/projections.html), except UTM.  
* Implemented [duck typing](https://en.wikipedia.org/wiki/Duck_typing) to enable more flexibility for the type of array plotted (i.e. xarray.DataArray vs. numpy.ndarray). Along with array type flexibility, we now support plotting MPAS component coupler fields, which have different dimension names than fields directly from the MPAS components (e.g. domo\_nx/domi\_nx vs nCells), but have the same shape and ordering.  
* Enabled [contouring](https://docs.e3sm.org/mosaic/user_guide/contouring.html) of cell centered fields directly on the native mesh. The contours produced on the native mesh lie on edges between cells, delineating the boundary between the contour threshold (cf. a marching triangles algorithm that does linearly interpolation of contour boundaries.)  
* A subtle change in how we interface with cartopy.mpl.geoxes.GeoAxes has produced *at least* a 50% reduction in rendering times.

**MPAS-Analysis** 1.15.0:

* Many bug fixes, particularly focused on to model vs. model analysis

**NCO** 5.3.9:

* Flexible months in ncclimo: Climos can start in any month (not just January)  
* Support EAMxx diurnal climos of instantaneous fields  
* Improved mbtempest support  
* I/O buffer-size control in ncremap/ncclimo can improve speed with netCDF-classic files

**xcdat** 0.11.2 (since 0.10.1):

* Added land-sea mask generation, the main new user-facing feature in this range.  
* Improved startup performance by deferring xgcm imports, reducing startup time by about 3 seconds.  
* Improved compatibility and correctness with newer Xarray behavior, including fixes to coordinate assignment and land-sea mask attribute  
* Full changelog: [History — xCDAT Documentation](https://xcdat.readthedocs.io/en/latest/history.html)

**zppy** 3.2.0:

* LIVVkit ice sheet analysis is now available as a new task.  
* MPAS-Analysis model-vs-model functionality is now supported.  
* E3SM Diagnostics now has two more sets: precip\_pdf and mp\_partition.

**zppy-interfaces** 0.2.1:

* Patch update. The ocean plots of the global\_time\_series original plots sets can now be made even if no atmosphere data is available.

**zstash** 1.6.0:

* zstash update now implements a major performance improvement (using scandir), thus decreasing runtimes.  
* zstash now correctly deletes tars when \--non-blocking is set, but \--keep is *not*. Previously, zstash had been keeping the tars regardless of \--keep's value, which could be an issue if disk space is low.


## Deployment
Deployed on:
- [x] Andes
- [x] Aurora
- [x] Chrysalis
- [x] Compy
- [ ] Dane
- [x] Frontier
- [x] Perlmutter-CPU
- [x] ALCF Polaris

## Sync Diagnostics
Synced on:
- [x] Andes
- [x] Aurora
- [x] Chrysalis
- [x] Compy
- [ ] Dane
- [x] Frontier
- [x] Perlmutter-CPU
- [x] ALCF Polaris

## Delete old test envs
- [x] Andes
- [x] Aurora
- [x] Chrysalis
- [x] Compy
- [ ] Dane
- [x] Frontier
- [x] Perlmutter-CPU
- [x] ALCF Polaris

Fixes #150 