### PR TITLE
Fix group write permissions on root for env links for NCO

### DIFF
--- a/deploy/cli_spec.json
+++ b/deploy/cli_spec.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "software": "e3sm-unified",
-    "mache_version": "3.6.1",
+    "mache_version": "3.7.0",
     "description": "Deploy e3sm-unified environment"
   },
   "arguments": [

--- a/deploy/hooks.py
+++ b/deploy/hooks.py
@@ -349,7 +349,10 @@ def pre_publish(ctx: DeployContext) -> dict[str, Any] | None:
 
     return {
         'shared': {
-            'managed_directories': [str(nco_root)],
+            'managed_directories': [{
+                'path': str(nco_root),
+                'root_group_writable': True,
+            }]
         }
     }
 

--- a/deploy/pins.cfg
+++ b/deploy/pins.cfg
@@ -2,7 +2,7 @@
 [pixi]
 bootstrap_python = 3.13
 python = 3.13
-mache = 3.6.1
+mache = 3.7.0
 
 # pins for the spack environment
 [spack]

--- a/pixi.toml
+++ b/pixi.toml
@@ -6,7 +6,7 @@ channel-priority = "strict"
 
 [dependencies]
 python = ">=3.11,<3.14"
-mache = "==3.3.0"
+mache = "==3.7.0"
 pytest = "*"
 pyyaml = "*"
 rattler-build = "*"

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -29,6 +29,16 @@ CURRENT_RECIPE_VERSION = deploy_hooks.get_version_from_recipe(
 )
 
 
+def _assert_managed_nco_root(updates: dict, nco_root: Path) -> None:
+    assert updates is not None
+    assert updates['shared']['managed_directories'] == [
+        {
+            'path': str(nco_root),
+            'root_group_writable': True,
+        }
+    ]
+
+
 def _write_machine_cfg(
     tmp_path: Path,
     *,
@@ -144,11 +154,7 @@ def test_pre_publish_falls_back_to_pixi_prefix_without_login_prefix(
 
     nco_root = base_path / 'e3smu_latest_for_nco'
     machine_link = nco_root / 'polaris'
-    assert updates == {
-        'shared': {
-            'managed_directories': [str(nco_root)],
-        }
-    }
+    _assert_managed_nco_root(updates, nco_root)
     assert machine_link.is_symlink()
     assert machine_link.readlink() == Path(ctx.runtime['pixi']['prefix'])
 
@@ -174,11 +180,7 @@ def test_pre_publish_adds_nco_alias_for_dual_env_release(tmp_path: Path):
 
     nco_root = base_path / 'e3smu_latest_for_nco'
     machine_link = nco_root / 'compy'
-    assert updates == {
-        'shared': {
-            'managed_directories': [str(nco_root)],
-        }
-    }
+    _assert_managed_nco_root(updates, nco_root)
     assert machine_link.is_symlink()
     assert machine_link.readlink() == Path(ctx.runtime['pixi']['login_prefix'])
 


### PR DESCRIPTION
We need the root to be group writable so multiple deployers can make use of the same root.

This requires updating to mache 3.7.0

Fixes #151 